### PR TITLE
fix/106-recruit-empty-response

### DIFF
--- a/src/entities/recruit/api/recruit.api.ts
+++ b/src/entities/recruit/api/recruit.api.ts
@@ -1,12 +1,12 @@
 import { getParsed, postParsed } from "src/shared/libs/api/zod";
 import {
-    recruitListResponseSchema,
-    recruitDetailResponseSchema,
-    recruitApplyResponseSchema,
-    type RecruitResponse,
-    type RecruitApplyResponse,
+	recruitListResponseSchema,
+	recruitDetailResponseSchema,
+	recruitApplyResponseSchema,
+	type RecruitResponse,
+	type RecruitApplyResponse,
+	type RecruitRequest,
 } from "../model/schema/recruit.schema";
-import type { ApplyFormValues } from "src/features/recruit/apply/form/model/schema/apply.schema";
 
 export interface RecruitSearchFilters {
     keyword?: string;
@@ -45,7 +45,11 @@ export const getRecruitListApi = async ({
         },
     });
 
-    return data ?? [];
+    // 서버에서 빈 데이터 시 문자열 반환할 수 있음
+    if (!data || typeof data === "string") {
+        return [];
+    }
+    return data;
 };
 
 /* 상세 */
@@ -58,9 +62,9 @@ export const getRecruitDetailApi = async (idx: number, signal?: AbortSignal) => 
     return data;
 };
 
-/* 지원 */
+/** 지원 */
 export const postRecruitApplyApi = async (
-    body: ApplyFormValues,
-    signal?: AbortSignal
+	body: RecruitRequest,
+	signal?: AbortSignal,
 ): Promise<RecruitApplyResponse> =>
-    postParsed("/recruit", recruitApplyResponseSchema, body, { signal });
+	postParsed("/recruit", recruitApplyResponseSchema, body, { signal });

--- a/src/entities/recruit/model/schema/recruit.schema.ts
+++ b/src/entities/recruit/model/schema/recruit.schema.ts
@@ -70,7 +70,16 @@ export const recruitApplicantSchema = recruitRequestSchema.extend({
     modifiedAt: z.string(),
 });
 
-export const recruitListResponseSchema = baseResponseSchema(recruitResponseSchema.array());
+/**
+ * @description
+ * 목록 응답 스키마. 서버에서 빈 데이터 시 문자열을 반환할 수 있어 union 처리
+ */
+export const recruitListResponseSchema = z.object({
+	status: z.number(),
+	message: z.string(),
+	data: z.union([recruitResponseSchema.array(), z.string(), z.null()]).optional(),
+}).passthrough();
+
 export const recruitDetailResponseSchema = baseResponseSchema(recruitResponseSchema);
 export type RecruitListResponse = z.infer<typeof recruitListResponseSchema>;
 export type RecruitDetailResponse = z.infer<typeof recruitDetailResponseSchema>;

--- a/src/shared/libs/api/zod/index.ts
+++ b/src/shared/libs/api/zod/index.ts
@@ -3,13 +3,28 @@ import BigtabletAxios from "src/shared/libs/api/axios";
 
 type AxiosConfig = Record<string, unknown>;
 
+/**
+ * @description
+ * 204 No Content 응답 시 빈 응답 객체 반환
+ */
+const handleNoContent = <S extends z.ZodTypeAny>(
+	status: number,
+	data: unknown,
+	schema: S,
+): z.infer<S> => {
+	if (status === 204 || data === "" || data === null || data === undefined) {
+		return schema.parse({ status: 204, message: "No Content", data: null });
+	}
+	return schema.parse(data);
+};
+
 export const getParsed = async <S extends z.ZodTypeAny>(
     url: string,
     schema: S,
     config?: AxiosConfig
 ): Promise<z.infer<S>> => {
     const res = await BigtabletAxios.get<unknown>(url, config);
-    return schema.parse(res.data);
+    return handleNoContent(res.status, res.data, schema);
 };
 
 export const postParsed = async <S extends z.ZodTypeAny>(


### PR DESCRIPTION
## 제목
Recruit 204 No Content 응답 처리

## 작업한 내용
- `getParsed`에 `handleNoContent` 헬퍼 추가하여 204 응답 처리
- `recruitListResponseSchema`에서 data 필드를 union 타입으로 처리 (배열 | 문자열 | null)
- `getRecruitListApi`에서 data가 null/문자열일 경우 빈 배열 반환

## 전달할 추가 이슈
- 없음

closes #106