### PR TITLE
style/recruit-header-cleanup

### DIFF
--- a/src/widgets/recruit/main/header/index.tsx
+++ b/src/widgets/recruit/main/header/index.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import { Button, Select, TextField, type SelectOption } from "@bigtablet/design-system";
+import {
+	Button,
+	Select,
+	TextField,
+	type SelectOption,
+} from "@bigtablet/design-system";
 import { memo, useMemo, useState } from "react";
+
 import {
 	DEPARTMENTS,
 	EDUCATIONS,
@@ -10,19 +16,15 @@ import {
 	educationLabel,
 	recruitTypeLabel,
 } from "src/entities/recruit/constants/recruit.constants";
-import styles from "./style.module.scss";
+import type { RecruitSearchFilters } from "src/entities/recruit/api/recruit.api";
 import type {
 	DepartmentType,
 	EducationType,
 	RecruitType,
 } from "src/entities/recruit/schema/recruit.enum";
-import { RecruitSearchFilters } from "src/entities/recruit/api/recruit.api";
-import { z } from "zod";
 import TalentFormModal from "src/features/talent/form/modal";
 
-type DepartmentCode = z.infer<typeof DepartmentType>;
-type EducationCode = z.infer<typeof EducationType>;
-type RecruitTypeCode = z.infer<typeof RecruitType>;
+import styles from "./style.module.scss";
 
 interface Props {
 	filters: RecruitSearchFilters;
@@ -30,21 +32,34 @@ interface Props {
 }
 
 const RecruitHeader = ({ filters, onChange }: Props) => {
-	const patch = (p: Partial<RecruitSearchFilters>) => onChange({ ...filters, ...p });
+	const patch = (partial: Partial<RecruitSearchFilters>) =>
+		onChange({ ...filters, ...partial });
 	const [open, setOpen] = useState(false);
 
 	const departmentOptions: SelectOption[] = useMemo(
-		() => DEPARTMENTS.map((code: DepartmentCode) => ({ value: code, label: departmentLabel(code) })),
+		() =>
+			DEPARTMENTS.map((code: DepartmentType) => ({
+				value: code,
+				label: departmentLabel(code),
+			})),
 		[],
 	);
 
 	const educationOptions: SelectOption[] = useMemo(
-		() => EDUCATIONS.map((code: EducationCode) => ({ value: code, label: educationLabel(code) })),
+		() =>
+			EDUCATIONS.map((code: EducationType) => ({
+				value: code,
+				label: educationLabel(code),
+			})),
 		[],
 	);
 
 	const recruitTypeOptions: SelectOption[] = useMemo(
-		() => RECRUIT_TYPES.map((code: RecruitTypeCode) => ({ value: code, label: recruitTypeLabel(code) })),
+		() =>
+			RECRUIT_TYPES.map((code: RecruitType) => ({
+				value: code,
+				label: recruitTypeLabel(code),
+			})),
 		[],
 	);
 
@@ -92,7 +107,12 @@ const RecruitHeader = ({ filters, onChange }: Props) => {
 						className={styles.recruit_search_select}
 					/>
 
-					<Button variant="primary" size="sm" width="auto" onClick={() => setOpen(true)}>
+					<Button
+						variant="primary"
+						size="sm"
+						width="auto"
+						onClick={() => setOpen(true)}
+					>
 						인재풀 등록하기
 					</Button>
 				</div>

--- a/src/widgets/recruit/main/header/style.module.scss
+++ b/src/widgets/recruit/main/header/style.module.scss
@@ -1,50 +1,69 @@
 @use "@bigtablet/design-system/scss/token" as token;
 
 .recruit_header {
-  @include token.flex_column;
-  width: 100%;
-  gap: token.$spacing_2xl;
-  color: token.$text_normal;
-  padding: token.$spacing_3xl 0 token.$spacing_xl;
-  margin: 0 auto;
+	@include token.flex_column;
+	width: 100%;
+	gap: token.$spacing_2xl;
+	color: token.$text_normal;
+	padding: token.$spacing_3xl 0 token.$spacing_xl;
+	margin: 0 auto;
+
+	@include token.mobile {
+		gap: token.$spacing_lg;
+		padding: token.$spacing_xl 0 token.$spacing_md;
+	}
 }
 
 .recruit_header_text {
-  @include token.flex_column;
-  gap: token.$spacing_sm;
+	@include token.flex_column;
+	gap: token.$spacing_sm;
 
-  h2 {
-    @include token.heading_2;
-    font-size: token.$font_size_2xl;
-    color: token.$text_strong;
-  }
+	h2 {
+		@include token.heading_2;
+		/* heading_2 기본보다 큰 사이즈 적용 */
+		font-size: token.$font_size_2xl;
+		color: token.$text_strong;
+	}
 
-  p {
-    @include token.body_medium;
-    font-size: token.$font_size_lg;
-    color: token.$text_subtle;
-  }
+	p {
+		@include token.body_medium;
+		/* body_medium 기본보다 큰 사이즈 적용 */
+		font-size: token.$font_size_lg;
+		color: token.$text_subtle;
+	}
+
+	@include token.mobile {
+		h2 {
+			font-size: token.$font_size_xl;
+		}
+
+		p {
+			font-size: token.$font_size_md;
+		}
+	}
 }
 
 .recruit_divider {
-  width: 100%;
-  height: 1px;
-  background: token.$color_border_light;
+	width: 100%;
+	height: 1px;
+	border: none;
+	margin: 0;
+	background: token.$color_border_light;
 }
 
 .recruit_search {
-  @include token.flex_center;
-  flex-wrap: wrap;
-  gap: token.$spacing_sm;
-  width: 100%;
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: token.$spacing_sm;
+	width: 100%;
 }
 
 .recruit_search_field {
-  flex: 1 1 200px;
-  min-width: 0;
+	flex: 1 1 200px;
+	min-width: 0;
 }
 
 .recruit_search_select {
-  width: auto;
+	width: auto;
 }
-


### PR DESCRIPTION
## 제목
style/recruit-header-cleanup

## 작업한 내용
- [x] import 순서 정리 (외부 → 내부 → 상대경로)
- [x] 불필요한 타입 별칭 및 zod import 제거
- [x] RecruitSearchFilters에 import type 적용
- [x] 파라미터 약어 수정 (p → partial)
- [x] 타이포그래피 mixin 오버라이드 의도 주석 추가
- [x] hr 요소 브라우저 기본 스타일 리셋 (border, margin)
- [x] 모바일 반응형 스타일 추가
- [x] flex_center → flex + align-items: center 로 좌측 정렬 변경

Closes #142

## 전달할 추가 이슈
- 없음