### PR TITLE
fix/code-quality

### DIFF
--- a/src/app/(i18n)/about/[id]/client.tsx
+++ b/src/app/(i18n)/about/[id]/client.tsx
@@ -34,7 +34,7 @@ const MemberDetailClient = () => {
 			: undefined,
 	};
 
-	const qaList = QaList(t as any, id, 20);
+	const qaList = QaList({ get: (k: string) => t(k), has: t.has }, id, 20);
 
 	return (
 		<section className={styles.member_detail} aria-label="Team member detail">

--- a/src/app/(i18n)/about/page.tsx
+++ b/src/app/(i18n)/about/page.tsx
@@ -11,11 +11,9 @@ type HistoryRawItem =
 	| { title: string; id?: string; description?: string; dateLabel?: string };
 
 const About = () => {
-	const messages = useMessages() as any;
-	const historyByYear = (messages?.about?.history ?? {}) as Record<
-		string,
-		HistoryRawItem[]
-	>;
+	const messages = useMessages() as Record<string, Record<string, unknown>>;
+	const historyByYear = ((messages?.about as Record<string, unknown>)
+		?.history ?? {}) as Record<string, HistoryRawItem[]>;
 
 	const items: HistorySchema[] = Object.entries(historyByYear).flatMap(
 		([year, list]) =>

--- a/src/app/(i18n)/blog/[idx]/client.tsx
+++ b/src/app/(i18n)/blog/[idx]/client.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import Image from "next/image";
 import { notFound } from "next/navigation";
 import { useLocale } from "next-intl";
 import { useEffect, useRef } from "react";
-import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+
+const ReactMarkdown = dynamic(() => import("react-markdown"), { ssr: false });
+
 import { useBlogViewMutation } from "src/features/blog/mutation/blog.mutation";
 import { useBlogDetailQuery } from "src/features/blog/query/blog.query";
 import { formatRelative } from "src/shared/libs/ui/date";

--- a/src/app/(i18n)/recruit/[idx]/client.tsx
+++ b/src/app/(i18n)/recruit/[idx]/client.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { Button } from "@bigtablet/design-system";
+import dynamic from "next/dynamic";
 import { useParams } from "next/navigation";
-import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
+
+const ReactMarkdown = dynamic(() => import("react-markdown"), { ssr: false });
+
 import { useRecruitDetailQuery } from "src/features/recruit/query/recruit.query";
 import { BigtabletLink } from "src/shared/hooks/next";
 import BackLink from "src/shared/ui/back-link";
@@ -42,16 +45,16 @@ const HIRING_PROCESS = [
 ];
 
 const markdownComponents = {
-	p: ({ node, ...props }: any) => (
+	p: (props: React.ComponentProps<"p">) => (
 		<p {...props} className={styles.recruit_detail_text} />
 	),
-	ul: ({ node, ...props }: any) => (
+	ul: (props: React.ComponentProps<"ul">) => (
 		<ul {...props} className={styles.recruit_detail_list} />
 	),
-	ol: ({ node, ...props }: any) => (
+	ol: (props: React.ComponentProps<"ol">) => (
 		<ol {...props} className={styles.recruit_detail_list} />
 	),
-	li: ({ node, ...props }: any) => <li {...props} />,
+	li: (props: React.ComponentProps<"li">) => <li {...props} />,
 };
 
 const RecruitDetailClient = () => {
@@ -74,7 +77,7 @@ const RecruitDetailClient = () => {
 
 			{status === "error" && (
 				<div className={styles.recruit_detail_error}>
-					불러오지 못했습니다. {(error as Error)?.message}
+					불러오지 못했습니다. {error instanceof Error ? error.message : ""}
 				</div>
 			)}
 

--- a/src/entities/blog/api/blog.api.ts
+++ b/src/entities/blog/api/blog.api.ts
@@ -9,20 +9,25 @@ import { getParsed, patchParsed } from "src/shared/libs/api/zod";
 import type { ListSchema } from "src/shared/schema/list/list.schema";
 
 // 리스트
-export const getBlogApi = async ({ page, size }: ListSchema) => {
+export const getBlogApi = async (
+	{ page, size }: ListSchema,
+	signal?: AbortSignal,
+) => {
 	return getParsed("/blog/list", blogListResponseSchema, {
 		params: { page, size },
+		signal,
 	}).then((response) => response.data ?? []);
 };
 
 // 상세
-export const getBlogDetailApi = async (idx: number) =>
-	getParsed("/blog", blogDetailResponseSchema, { params: { idx } }).then(
-		(response: BlogDetailResponse) => {
-			if (!response.data) throw new Error("Empty response");
-			return response.data;
-		},
-	);
+export const getBlogDetailApi = async (idx: number, signal?: AbortSignal) =>
+	getParsed("/blog", blogDetailResponseSchema, {
+		params: { idx },
+		signal,
+	}).then((response: BlogDetailResponse) => {
+		if (!response.data) throw new Error("Empty response");
+		return response.data;
+	});
 
 // 조회수 증가
 export const patchBlogViewApi = async (idx: number) =>

--- a/src/entities/news/api/news.api.ts
+++ b/src/entities/news/api/news.api.ts
@@ -6,11 +6,12 @@ import { getParsed } from "src/shared/libs/api/zod";
 import type { ListSchema } from "src/shared/schema/list/list.schema";
 
 // 목록
-export const getNewsApi = async ({
-	page,
-	size,
-}: ListSchema): Promise<NewsListResponse> => {
+export const getNewsApi = async (
+	{ page, size }: ListSchema,
+	signal?: AbortSignal,
+): Promise<NewsListResponse> => {
 	return getParsed("/news/list", newsListResponseSchema, {
 		params: { page, size },
+		signal,
 	});
 };

--- a/src/entities/news/schema/news.schema.ts
+++ b/src/entities/news/schema/news.schema.ts
@@ -16,5 +16,4 @@ export type NewsItem = z.infer<typeof newsItemSchema>;
 export const newsListResponseSchema = baseResponseSchema(
 	z.array(newsItemSchema),
 );
-baseResponseSchema(newsItemSchema);
 export type NewsListResponse = z.infer<typeof newsListResponseSchema>;

--- a/src/entities/talent/schema/talent.schema.ts
+++ b/src/entities/talent/schema/talent.schema.ts
@@ -21,10 +21,7 @@ export type PostTalentFormValues = {
 	portfolioUrl: string;
 	etcUrl: string[];
 };
-z.object({
-	idx: z.number(),
-	text: z.string(),
-});
+
 export const getTalentDetailResponseSchema = baseResponseSchema(
 	z.object({
 		idx: z.number(),
@@ -36,5 +33,3 @@ export const getTalentDetailResponseSchema = baseResponseSchema(
 		createdAt: z.string(),
 	}),
 );
-baseResponseSchema(z.array(getTalentDetailResponseSchema));
-baseResponseSchema(z.array(getTalentDetailResponseSchema));

--- a/src/features/blog/query/blog.query.ts
+++ b/src/features/blog/query/blog.query.ts
@@ -15,23 +15,21 @@ export interface BlogPageResult {
 export const useBlogPageQuery = ({ page, size }: ListSchema) =>
 	useQuery<BlogPageResult>({
 		queryKey: blogQueryKeys.page(page, size),
-		queryFn: async () => {
+		queryFn: async ({ signal }) => {
 			const over = size + 1;
-			const rows = await getBlogApi({ page, size: over });
+			const rows = await getBlogApi({ page, size: over }, signal);
 
 			const hasNext = rows.length > size;
 			const items = hasNext ? rows.slice(0, size) : rows;
 
 			return { items, hasNext };
 		},
-		staleTime: 3_600_000,
 	});
 
 /** 상세 조회 */
 export const useBlogDetailQuery = (idx: number) =>
 	useQuery<BlogItem>({
 		queryKey: blogQueryKeys.detail(idx),
-		queryFn: () => getBlogDetailApi(idx),
+		queryFn: ({ signal }) => getBlogDetailApi(idx, signal),
 		enabled: Number.isFinite(idx) && idx > 0,
-		staleTime: 3_600_000,
 	});

--- a/src/features/news/query/news.query.ts
+++ b/src/features/news/query/news.query.ts
@@ -20,8 +20,8 @@ export const useNewsPageQuery = ({
 }) =>
 	useQuery<NewsPageResult>({
 		queryKey: newsQueryKeys.page(page, size),
-		queryFn: async () => {
-			const res = await getNewsApi({ page, size });
+		queryFn: async ({ signal }) => {
+			const res = await getNewsApi({ page, size }, signal);
 
 			const items = res.data ?? [];
 
@@ -30,5 +30,4 @@ export const useNewsPageQuery = ({
 				hasNext: items.length === size,
 			};
 		},
-		staleTime: 3_600_000,
 	});

--- a/src/features/recruit/apply/form/email/use-email-verification.ts
+++ b/src/features/recruit/apply/form/email/use-email-verification.ts
@@ -6,6 +6,7 @@ import {
 	checkEmailApi,
 	sendEmailApi,
 } from "src/features/recruit/apply/form/email/api/email.api";
+import { getErrorMessage } from "src/shared/libs/api/axios/error/error.util";
 
 interface UseEmailVerificationParams {
 	getEmail: () => string;
@@ -48,8 +49,8 @@ const useEmailVerification = ({
 			setEmailSent(true);
 			setResendSec(cooldownSec);
 			Toast.success("인증 코드가 전송되었습니다. 메일함을 확인해주세요.");
-		} catch (e: any) {
-			Toast.error(e?.response?.data?.message ?? "이메일 전송 실패");
+		} catch (e: unknown) {
+			Toast.error(getErrorMessage(e, "이메일 전송 실패"));
 		} finally {
 			setSendLoading(false);
 		}
@@ -63,9 +64,9 @@ const useEmailVerification = ({
 			await checkEmailApi(email, authCode);
 			setEmailVerified(true);
 			Toast.success("이메일 인증이 완료되었습니다.");
-		} catch (e: any) {
+		} catch (e: unknown) {
 			setEmailVerified(false);
-			Toast.error(e?.response?.data?.message ?? "인증 실패");
+			Toast.error(getErrorMessage(e, "인증 실패"));
 		} finally {
 			setCheckLoading(false);
 		}

--- a/src/features/talent/form/model/use-talent-form.ts
+++ b/src/features/talent/form/model/use-talent-form.ts
@@ -9,6 +9,7 @@ import type {
 } from "src/entities/talent/schema/talent.schema";
 import { useTalentMutation } from "src/features/talent/mutation/talent.mutation";
 import { useUploadMutation } from "src/features/upload/mutation/upload.mutation";
+import { getErrorMessage } from "src/shared/libs/api/axios/error/error.util";
 import { validateFile } from "src/shared/libs/file/validate";
 
 type PortfolioMode = "link" | "file";
@@ -43,9 +44,10 @@ export const useTalentForm = ({ onClose }: UseTalentFormParams) => {
 		shouldUnregister: false,
 	});
 
-	const { fields, append, remove } = useFieldArray<any>({
-		control: form.control as any,
-		name: "etcUrl",
+	// useFieldArray는 원시 배열(string[])을 직접 지원하지 않아 타입 단언 필요
+	const { fields, append, remove } = useFieldArray({
+		control: form.control as never,
+		name: "etcUrl" as never,
 	});
 
 	const handlePortfolioFile = async (file: File | null) => {
@@ -87,12 +89,8 @@ export const useTalentForm = ({ onClose }: UseTalentFormParams) => {
 			form.reset();
 			setPortfolioMode("link");
 			onClose();
-		} catch (error: any) {
-			const message =
-				error?.response?.data?.message ||
-				error?.message ||
-				"등록 중 오류가 발생했습니다.";
-			Toast.error(message);
+		} catch (error: unknown) {
+			Toast.error(getErrorMessage(error, "등록 중 오류가 발생했습니다."));
 		}
 	};
 

--- a/src/shared/libs/api/gcp/gcp.api.ts
+++ b/src/shared/libs/api/gcp/gcp.api.ts
@@ -25,6 +25,7 @@ export const postGcpUploadApi = async (
 
 	const res = await BigtabletAxios.post("/gcp", formData, {
 		signal,
+		timeout: 30000,
 		withCredentials: false,
 		headers: { "Content-Type": "multipart/form-data" },
 	});

--- a/src/widgets/about/member/model/use-qa-list.ts
+++ b/src/widgets/about/member/model/use-qa-list.ts
@@ -5,8 +5,13 @@ export interface QAItem {
 	a: string;
 }
 
+export interface TranslationAccessor {
+	get: (k: string) => string;
+	has: (k: string) => boolean;
+}
+
 export const QaList = (
-	t: { (k: string): string; has: (k: string) => boolean },
+	t: TranslationAccessor,
 	memberKey: MemberKey,
 	max = 20,
 ): QAItem[] => {
@@ -14,5 +19,5 @@ export const QaList = (
 	return Array.from({ length: max }, (_, i) => i + 1)
 		.map((n) => ({ qKey: `${base}.qa${n}.q`, aKey: `${base}.qa${n}.a` }))
 		.filter(({ qKey, aKey }) => t.has(qKey) && t.has(aKey))
-		.map(({ qKey, aKey }) => ({ q: t(qKey), a: t(aKey) }));
+		.map(({ qKey, aKey }) => ({ q: t.get(qKey), a: t.get(aKey) }));
 };

--- a/src/widgets/layout/provider/index.tsx
+++ b/src/widgets/layout/provider/index.tsx
@@ -11,7 +11,15 @@ export default function Providers({ children }: Props) {
 		() =>
 			new QueryClient({
 				defaultOptions: {
-					queries: { retry: 1 },
+					queries: {
+						staleTime: 1000 * 60 * 60,
+						gcTime: 1000 * 60 * 60 * 2,
+						retry: (failureCount, error) => {
+							const status = (error as { status?: number }).status;
+							if (status && status >= 400 && status < 500) return false;
+							return failureCount < 1;
+						},
+					},
 				},
 			}),
 	);

--- a/src/widgets/main/collaborations/index.tsx
+++ b/src/widgets/main/collaborations/index.tsx
@@ -42,7 +42,7 @@ const Collaborations = ({ speed = 40 }: { speed?: number }) => {
 			<div
 				className={styles.collabs_viewport}
 				ref={ref}
-				style={{ ["--gap" as any]: `${GAP}px` }}
+				style={{ "--gap": `${GAP}px` } as React.CSSProperties}
 			>
 				<Marquee gradient={false} speed={speed}>
 					{items.map((src, i) => (


### PR DESCRIPTION
## 제목
fix/code-quality

## 작업한 내용
- [x] React Query staleTime(1h), gcTime(2h), smart retry 최적화
- [x] AbortSignal 지원 추가 (blog, news API)
- [x] GCP 업로드 타임아웃 30초로 증가
- [x] getErrorMessage 유틸로 에러 처리 통일
- [x] as any 캐스트 제거 및 타입 안전성 개선
- [x] 불필요한 스키마 정의 정리 (talent, news)
- [x] react-markdown lazy loading 적용 (blog, recruit 상세)
- [x] ToastProvider children wrapping 수정

## 전달할 추가 이슈
- 없음

Closes #163