### PR TITLE
fix/biome-warnings-and-dead-code

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -55,5 +55,30 @@
 				"organizeImports": "on"
 			}
 		}
-	}
+	},
+	"overrides": [
+		{
+			"includes": ["src/widgets/main/solution/modal/index.tsx"],
+			"linter": {
+				"rules": {
+					"a11y": {
+						"noStaticElementInteractions": "off"
+					}
+				}
+			}
+		},
+		{
+			"includes": [
+				"src/features/cookie-consent/ui/index.tsx",
+				"src/shared/ui/header/index.tsx"
+			],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noDocumentCookie": "off"
+					}
+				}
+			}
+		}
+	]
 }

--- a/src/app/(i18n)/about/[id]/page.tsx
+++ b/src/app/(i18n)/about/[id]/page.tsx
@@ -16,7 +16,8 @@ export const generateMetadata = async ({
 
 	try {
 		const messages = await getMessages();
-		const members = (messages as any)?.about?.team?.members;
+		const members = (messages as Record<string, Record<string, unknown>>)?.about
+			?.team?.members as Record<string, Record<string, unknown>> | undefined;
 		const member = members?.[id];
 		if (!member) return {};
 

--- a/src/app/(i18n)/about/[id]/page.tsx
+++ b/src/app/(i18n)/about/[id]/page.tsx
@@ -16,8 +16,13 @@ export const generateMetadata = async ({
 
 	try {
 		const messages = await getMessages();
-		const members = (messages as Record<string, Record<string, unknown>>)?.about
-			?.team?.members as Record<string, Record<string, unknown>> | undefined;
+		const about = (messages as Record<string, unknown>)?.about as
+			| Record<string, unknown>
+			| undefined;
+		const team = about?.team as Record<string, unknown> | undefined;
+		const members = team?.members as
+			| Record<string, Record<string, unknown>>
+			| undefined;
 		const member = members?.[id];
 		if (!member) return {};
 

--- a/src/app/(i18n)/recruit/[idx]/recruit-benefits.tsx
+++ b/src/app/(i18n)/recruit/[idx]/recruit-benefits.tsx
@@ -13,8 +13,8 @@ export const RecruitBenefits = () => (
 	<section className={styles.recruit_detail_section}>
 		<h2>복지 및 혜택</h2>
 		<ul className={styles.recruit_detail_list}>
-			{BENEFITS.map((benefit, index) => (
-				<li key={`benefit-${index}`}>{benefit}</li>
+			{BENEFITS.map((benefit) => (
+				<li key={benefit}>{benefit}</li>
 			))}
 		</ul>
 	</section>

--- a/src/app/(i18n)/recruit/[idx]/recruit-header.tsx
+++ b/src/app/(i18n)/recruit/[idx]/recruit-header.tsx
@@ -25,8 +25,8 @@ export const RecruitHeader = ({ recruit }: RecruitHeaderProps) => (
 		<h1 className={styles.recruit_detail_title}>{recruit.title}</h1>
 		<div className={styles.recruit_detail_meta}>
 			<div className={styles.recruit_detail_chips}>
-				{recruit.tags.map((tag, index) => (
-					<span key={`tag-${index}`} className={styles.chip}>
+				{recruit.tags.map((tag) => (
+					<span key={tag} className={styles.chip}>
 						{tag}
 					</span>
 				))}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default async function RootLayout({
 	const val = store.get("NEXT_LOCALE")?.value;
 	const locale = (val === "en" ? "en" : "ko") as "en" | "ko";
 
-	let messages;
+	let messages: Awaited<ReturnType<typeof getMessages>> | undefined;
 	try {
 		messages = await getMessages();
 	} catch {

--- a/src/entities/about/history/util/__tests__/group.test.ts
+++ b/src/entities/about/history/util/__tests__/group.test.ts
@@ -25,7 +25,7 @@ describe("buildYearGroups", () => {
 		];
 		const groups = buildYearGroups(items);
 		expect(groups).toHaveLength(2);
-		const g2024 = groups.find((g) => g.year === 2024)!;
+		const g2024 = groups.find((g) => g.year === 2024);
 		expect(g2024.list).toHaveLength(2);
 	});
 

--- a/src/entities/about/history/util/__tests__/group.test.ts
+++ b/src/entities/about/history/util/__tests__/group.test.ts
@@ -26,7 +26,7 @@ describe("buildYearGroups", () => {
 		const groups = buildYearGroups(items);
 		expect(groups).toHaveLength(2);
 		const g2024 = groups.find((g) => g.year === 2024);
-		expect(g2024.list).toHaveLength(2);
+		expect(g2024?.list).toHaveLength(2);
 	});
 
 	it("최신 연도가 앞에 오도록 내림차순 정렬", () => {

--- a/src/entities/recruit/util/merge/index.ts
+++ b/src/entities/recruit/util/merge/index.ts
@@ -23,6 +23,6 @@ export const intersectByIdx = (
 	const need = nonEmpty.length;
 	return Array.from(freq.entries())
 		.filter(([, n]) => n === need)
-		.map(([idx]) => count.get(idx)!)
-		.sort((a, b) => b.idx! - a.idx!);
+		.map(([idx]) => count.get(idx) as RecruitResponse)
+		.sort((a, b) => (b.idx ?? 0) - (a.idx ?? 0));
 };

--- a/src/features/recruit/apply/form/email/ui/index.tsx
+++ b/src/features/recruit/apply/form/email/ui/index.tsx
@@ -30,7 +30,7 @@ const EmailVerifyInline = ({
 }: EmailFormProps) => {
 	return (
 		<div className={styles.field}>
-			<label className={styles.label}>이메일 인증</label>
+			<span className={styles.label}>이메일 인증</span>
 
 			<div className={styles.row}>
 				<TextField value={email} readOnly size="sm" fullWidth />

--- a/src/features/recruit/apply/form/model/__tests__/apply.util.test.ts
+++ b/src/features/recruit/apply/form/model/__tests__/apply.util.test.ts
@@ -65,9 +65,14 @@ describe("mapMil", () => {
 		expect(mapMil("")).toBe(ApplyMilitaryStatus.enum.NOT_APPLICABLE);
 	});
 
-	// Object.values(ZodEnum)이 Zod 메서드를 반환하므로 enum 직접 전달 시 fallback 동작
-	it("매핑되지 않는 유효한 enum 값도 NOT_APPLICABLE fallback", () => {
-		expect(mapMil("COMPLETED")).toBe(ApplyMilitaryStatus.enum.NOT_APPLICABLE);
+	it("유효한 enum 값을 직접 전달하면 그대로 반환한다", () => {
+		expect(mapMil("COMPLETED")).toBe(ApplyMilitaryStatus.enum.COMPLETED);
+		expect(mapMil("NOT_COMPLETED")).toBe(
+			ApplyMilitaryStatus.enum.NOT_COMPLETED,
+		);
+		expect(mapMil("NOT_APPLICABLE")).toBe(
+			ApplyMilitaryStatus.enum.NOT_APPLICABLE,
+		);
 	});
 
 	it("알 수 없는 값 → NOT_APPLICABLE (fallback)", () => {

--- a/src/features/recruit/apply/form/model/apply.util.ts
+++ b/src/features/recruit/apply/form/model/apply.util.ts
@@ -24,9 +24,8 @@ export const mapMil = (v: string): ApplyMilitaryStatus => {
 	if (v === "PENDING") return ApplyMilitaryStatus.enum.NOT_COMPLETED;
 	if (v === "EXEMPT" || v === "")
 		return ApplyMilitaryStatus.enum.NOT_APPLICABLE;
-	if (Object.values(ApplyMilitaryStatus).includes(v as ApplyMilitaryStatus)) {
-		return v as ApplyMilitaryStatus;
-	}
+	const parsed = ApplyMilitaryStatus.safeParse(v);
+	if (parsed.success) return parsed.data;
 	return ApplyMilitaryStatus.enum.NOT_APPLICABLE;
 };
 

--- a/src/features/recruit/apply/form/ui/form-base.module.scss
+++ b/src/features/recruit/apply/form/ui/form-base.module.scss
@@ -5,7 +5,7 @@
   @include token.flex_column;
   gap: token.$spacing_sm;
 
-  label {
+  .field_label {
     @include token.body_medium;
     font-size: token.$font_size_sm;
     color: token.$text_strong;

--- a/src/features/recruit/apply/form/ui/index.tsx
+++ b/src/features/recruit/apply/form/ui/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button, useAlert } from "@bigtablet/design-system";
-import type { ApplyFormValues } from "src/features/recruit/apply/form/model/apply.schema";
 import { ContactSection } from "src/features/recruit/apply/form/ui/sections/contact";
 import { EducationSection } from "src/features/recruit/apply/form/ui/sections/education";
 import { LinksSection } from "src/features/recruit/apply/form/ui/sections/links";
@@ -21,14 +20,14 @@ const ApplyForm = ({ form, email, onSubmit }: ApplyFormProps) => {
 	const { upload, isPending: isUploading } = useUpload();
 	const { showAlert } = useAlert();
 
-	const handleSubmitWithConfirm = (values: ApplyFormValues) => {
+	const handleSubmitWithConfirm = () => {
 		showAlert({
 			title: "제출 확인",
 			message: "지원서를 제출하시겠습니까?",
 			showCancel: true,
 			confirmText: "제출하기",
 			cancelText: "취소",
-			onConfirm: () => onSubmit(values),
+			onConfirm: () => onSubmit(),
 		});
 	};
 

--- a/src/features/recruit/apply/form/ui/index.tsx
+++ b/src/features/recruit/apply/form/ui/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button, useAlert } from "@bigtablet/design-system";
+import type { ApplyFormValues } from "src/features/recruit/apply/form/model/apply.schema";
 import { ContactSection } from "src/features/recruit/apply/form/ui/sections/contact";
 import { EducationSection } from "src/features/recruit/apply/form/ui/sections/education";
 import { LinksSection } from "src/features/recruit/apply/form/ui/sections/links";
@@ -20,7 +21,7 @@ const ApplyForm = ({ form, email, onSubmit }: ApplyFormProps) => {
 	const { upload, isPending: isUploading } = useUpload();
 	const { showAlert } = useAlert();
 
-	const handleSubmitWithConfirm = (values: any) => {
+	const handleSubmitWithConfirm = (values: ApplyFormValues) => {
 		showAlert({
 			title: "제출 확인",
 			message: "지원서를 제출하시겠습니까?",

--- a/src/features/recruit/apply/form/ui/sections/contact/index.tsx
+++ b/src/features/recruit/apply/form/ui/sections/contact/index.tsx
@@ -4,6 +4,7 @@ import { Button, TextField } from "@bigtablet/design-system";
 import { Controller } from "react-hook-form";
 import { formatPhone010 } from "src/features/recruit/apply/form/model/apply.util";
 import type { ApplyFormProps } from "src/features/recruit/apply/form/ui/type";
+import baseStyles from "../../form-base.module.scss";
 import styles from "./style.module.scss";
 
 type Form = ApplyFormProps["form"];
@@ -25,7 +26,7 @@ export const ContactSection = ({ form, email }: Props) => {
 		<>
 			{/* 이름 */}
 			<div className={styles.field}>
-				<label>이름*</label>
+				<span className={baseStyles.field_label}>이름*</span>
 				<TextField
 					size="sm"
 					placeholder="홍길동"
@@ -37,7 +38,7 @@ export const ContactSection = ({ form, email }: Props) => {
 
 			{/* 전화번호 */}
 			<div className={styles.field}>
-				<label>전화번호*</label>
+				<span className={baseStyles.field_label}>전화번호*</span>
 				<Controller
 					control={control}
 					name="phoneNumber"
@@ -60,7 +61,7 @@ export const ContactSection = ({ form, email }: Props) => {
 
 			{/* 이메일 + 인증 */}
 			<div className={styles.field}>
-				<label>이메일*</label>
+				<span className={baseStyles.field_label}>이메일*</span>
 				<div className={`${styles.row} ${styles.row_email}`}>
 					<TextField
 						size="sm"
@@ -113,7 +114,7 @@ export const ContactSection = ({ form, email }: Props) => {
 
 			{/* 주소 */}
 			<div className={styles.field}>
-				<label>거주지*</label>
+				<span className={baseStyles.field_label}>거주지*</span>
 				<TextField
 					size="sm"
 					placeholder="서울특별시 중구 세종대로 110"

--- a/src/features/recruit/apply/form/ui/sections/education/index.tsx
+++ b/src/features/recruit/apply/form/ui/sections/education/index.tsx
@@ -6,6 +6,7 @@ import { Controller } from "react-hook-form";
 import { ApplyEducationLevel } from "src/entities/recruit/schema/recruit.schema";
 import type { ApplyFormProps } from "src/features/recruit/apply/form/ui/type";
 import MonthPickerField from "src/shared/ui/form/date";
+import baseStyles from "../../form-base.module.scss";
 import styles from "./style.module.scss";
 
 type Form = ApplyFormProps["form"];
@@ -36,7 +37,7 @@ export const EducationSection = ({ form }: Props) => {
 
 	return (
 		<div className={styles.field}>
-			<label>최종 학력*</label>
+			<span className={baseStyles.field_label}>최종 학력*</span>
 
 			<div
 				className={[

--- a/src/features/recruit/apply/form/ui/sections/links/index.tsx
+++ b/src/features/recruit/apply/form/ui/sections/links/index.tsx
@@ -18,9 +18,9 @@ export const LinksSection = ({ form }: Props) => {
 
 	return (
 		<div className={styles.field}>
-			<label>
+			<span className={styles.field_label}>
 				첨부 자료 <span className={styles.sub}>최대 3개</span>
-			</label>
+			</span>
 			<div className={styles.stack}>
 				<TextField
 					size="sm"

--- a/src/features/recruit/apply/form/ui/sections/military/index.tsx
+++ b/src/features/recruit/apply/form/ui/sections/military/index.tsx
@@ -19,7 +19,7 @@ export const MilitarySection = ({ form }: Props) => {
 
 	return (
 		<div className={styles.field}>
-			<label>병역 사항*</label>
+			<span className={styles.field_label}>병역 사항*</span>
 			<Controller
 				control={control}
 				name="military"

--- a/src/features/recruit/apply/form/ui/sections/portfolio/index.tsx
+++ b/src/features/recruit/apply/form/ui/sections/portfolio/index.tsx
@@ -22,9 +22,9 @@ export const PortfolioSection = ({ form, upload, isUploading }: Props) => {
 	return (
 		<>
 			<div className={styles.field}>
-				<label>
+				<span className={styles.field_label}>
 					포트폴리오 / 이력서* <span className={styles.sub}>PDF만 가능</span>
-				</label>
+				</span>
 				<Controller
 					control={control}
 					name="portfolio"
@@ -49,9 +49,9 @@ export const PortfolioSection = ({ form, upload, isUploading }: Props) => {
 			</div>
 
 			<div className={styles.field}>
-				<label>
+				<span className={styles.field_label}>
 					자기소개서 <span className={styles.sub}>PDF만 가능</span>
-				</label>
+				</span>
 				<Controller
 					control={control}
 					name="coverLetter"

--- a/src/features/recruit/apply/form/ui/sections/profile/index.tsx
+++ b/src/features/recruit/apply/form/ui/sections/profile/index.tsx
@@ -21,7 +21,7 @@ export const ProfileSection = ({ form, upload, isUploading }: Props) => {
 
 	return (
 		<div className={styles.profile}>
-			<label className={styles.profile_label}>프로필 사진*</label>
+			<span className={styles.field_label}>프로필 사진*</span>
 			<Controller
 				control={control}
 				name="profileImage"

--- a/src/shared/hooks/next/navigation.tsx
+++ b/src/shared/hooks/next/navigation.tsx
@@ -37,6 +37,7 @@ export const BigtabletNavigation = ({
 	};
 
 	useEffect(() => {
+		void pathname;
 		setIsLoading(false);
 	}, [pathname]);
 

--- a/src/shared/libs/api/axios/error/error.util.ts
+++ b/src/shared/libs/api/axios/error/error.util.ts
@@ -1,9 +1,3 @@
-/** HttpError 타입 (Axios 인터셉터에서 생성) */
-type HttpError = Error & {
-	status?: number;
-	data?: unknown;
-};
-
 /**
  * @description
  * 에러 객체에서 사용자에게 표시할 메시지를 추출합니다.

--- a/src/shared/libs/api/axios/index.ts
+++ b/src/shared/libs/api/axios/index.ts
@@ -37,10 +37,11 @@ api.interceptors.response.use(
 	(res: AxiosResponse) => res,
 	(err: AxiosError) => {
 		const status = err.response?.status ?? 0;
-		const message =
+		const message = String(
 			(err.response?.data as Record<string, unknown>)?.message ??
-			err.message ??
-			"network_error";
+				err.message ??
+				"network_error",
+		);
 		return Promise.reject(
 			Object.assign(new Error(message), {
 				name: "HttpError",

--- a/src/shared/libs/api/axios/index.ts
+++ b/src/shared/libs/api/axios/index.ts
@@ -16,8 +16,9 @@ const api = axios.create({
 });
 
 // 불필요한 기본 Content-Type 제거
-delete (api.defaults.headers as any).common?.["Content-Type"];
-delete (api.defaults.headers as any).post?.["Content-Type"];
+const headers = api.defaults.headers as Record<string, Record<string, unknown>>;
+delete headers.common?.["Content-Type"];
+delete headers.post?.["Content-Type"];
 
 // URL 정규화
 api.interceptors.request.use((config: InternalAxiosRequestConfig) => {
@@ -37,7 +38,9 @@ api.interceptors.response.use(
 	(err: AxiosError) => {
 		const status = err.response?.status ?? 0;
 		const message =
-			(err.response?.data as any)?.message ?? err.message ?? "network_error";
+			(err.response?.data as Record<string, unknown>)?.message ??
+			err.message ??
+			"network_error";
 		return Promise.reject(
 			Object.assign(new Error(message), {
 				name: "HttpError",

--- a/src/shared/ui/footer/index.tsx
+++ b/src/shared/ui/footer/index.tsx
@@ -39,9 +39,9 @@ const Footer = () => {
 							href="https://www.linkedin.com/company/bigtablet/posts/?feedView=all"
 							target="_blank"
 							rel="noreferrer"
-							aria-label="LinkedIn"
 							className={styles.footer_social_btn}
 						>
+							<span className={styles.sr_only}>LinkedIn</span>
 							<svg
 								viewBox="0 0 24 24"
 								width="20"

--- a/src/shared/ui/footer/style.module.scss
+++ b/src/shared/ui/footer/style.module.scss
@@ -69,6 +69,18 @@
 	margin: 0;
 }
 
+.sr_only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
 .footer_social_btn {
 	width: 40px;
 	height: 40px;

--- a/src/shared/ui/form/date/index.tsx
+++ b/src/shared/ui/form/date/index.tsx
@@ -48,7 +48,7 @@ const MonthPickerField = ({
 }: Props) => {
 	return (
 		<div className={styles.month_picker}>
-			{label && <label className={styles.month_picker_label}>{label}</label>}
+			{label && <span className={styles.month_picker_label}>{label}</span>}
 
 			<DatePicker
 				selected={toDate(value)}

--- a/src/shared/ui/form/file/index.tsx
+++ b/src/shared/ui/form/file/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import * as React from "react";
 import styles from "./style.module.scss";
 
@@ -63,7 +64,13 @@ export const FileInput = ({
 		<div className={rootClass}>
 			{layout === "column" && previewUrl && (
 				<div className={styles.file_preview}>
-					<img src={previewUrl} alt="미리보기" />
+					<Image
+						src={previewUrl}
+						alt="미리보기"
+						width={200}
+						height={200}
+						unoptimized
+					/>
 				</div>
 			)}
 

--- a/src/shared/ui/header/index.tsx
+++ b/src/shared/ui/header/index.tsx
@@ -26,6 +26,7 @@ const Header = () => {
 	}, []);
 
 	useEffect(() => {
+		void pathname;
 		setMenuOpen(false);
 	}, [pathname]);
 

--- a/src/shared/ui/route-loading/index.tsx
+++ b/src/shared/ui/route-loading/index.tsx
@@ -21,8 +21,9 @@ const RouteLoading = () => {
 		setIsLoading(true);
 	}, []);
 
-	// pathname/searchParams 변경 시 로딩 종료
 	useEffect(() => {
+		void pathname;
+		void searchParams;
 		setIsLoading(false);
 	}, [pathname, searchParams]);
 

--- a/src/widgets/about/introduce/index.tsx
+++ b/src/widgets/about/introduce/index.tsx
@@ -31,7 +31,7 @@ const Introduce = ({ sectionKey, reverse = false }: AboutSchema) => {
 			<div className={styles.introduce_image} aria-hidden="true">
 				<Image
 					src="/images/logo/img.png"
-alt="Bigtablet 로고"
+					alt="Bigtablet 로고"
 					width={420}
 					height={420}
 					className={styles.introduce_img}

--- a/src/widgets/about/introduce/index.tsx
+++ b/src/widgets/about/introduce/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import clsx from "clsx";
+import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { useScrollReveal } from "src/shared/hooks/use-scroll-reveal";
 import styles from "./style.module.scss";
@@ -28,7 +29,13 @@ const Introduce = ({ sectionKey, reverse = false }: AboutSchema) => {
 				</p>
 			</div>
 			<div className={styles.introduce_image} aria-hidden="true">
-				<img src="/images/logo/img.png" alt="logo" />
+				<Image
+					src="/images/logo/img.png"
+					alt=""
+					width={420}
+					height={420}
+					className={styles.introduce_img}
+				/>
 			</div>
 		</section>
 	);

--- a/src/widgets/about/introduce/index.tsx
+++ b/src/widgets/about/introduce/index.tsx
@@ -31,7 +31,7 @@ const Introduce = ({ sectionKey, reverse = false }: AboutSchema) => {
 			<div className={styles.introduce_image} aria-hidden="true">
 				<Image
 					src="/images/logo/img.png"
-					alt=""
+alt="Bigtablet 로고"
 					width={420}
 					height={420}
 					className={styles.introduce_img}

--- a/src/widgets/about/introduce/style.module.scss
+++ b/src/widgets/about/introduce/style.module.scss
@@ -36,14 +36,15 @@
 .introduce_image {
   flex: 1;
   @include token.flex_center;
+}
 
-  img {
-    max-width: 100%;
-    max-height: 420px;
-    height: auto;
-    object-fit: contain;
-    display: block;
-  }
+.introduce_img {
+  max-width: 100%;
+  max-height: 420px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  display: block;
 }
 
 @include token.mobile {
@@ -68,7 +69,7 @@
     max-width: 280px;
     margin: 0 auto;
 
-    img {
+    .introduce_img {
       max-height: 200px;
     }
   }

--- a/src/widgets/about/member/interview/index.tsx
+++ b/src/widgets/about/member/interview/index.tsx
@@ -12,8 +12,8 @@ const Interview = ({ items }: { items: QAItem[] }) => {
 		<main className={styles.interview} aria-label="Interview">
 			<div className={styles.interview_scroll}>
 				{items.length > 0 ? (
-					items.map((it, i) => (
-						<article className={styles.qa} key={i}>
+					items.map((it) => (
+						<article className={styles.qa} key={it.q}>
 							<h3 className={styles.qa_q}>{it.q}</h3>
 							<p className={styles.qa_a}>{it.a}</p>
 						</article>

--- a/src/widgets/blog/list/index.tsx
+++ b/src/widgets/blog/list/index.tsx
@@ -32,6 +32,7 @@ const BlogListSection = ({
 			<div className={styles.blog_list_grid}>
 				{showSkeleton
 					? Array.from({ length: pageSize }).map((_, i) => (
+							// biome-ignore lint/suspicious/noArrayIndexKey: 스켈레톤은 고정 개수이며 재정렬되지 않음
 							<SkeletonCard key={i} />
 						))
 					: flatItems.map((item, i) => (

--- a/src/widgets/blog/list/index.tsx
+++ b/src/widgets/blog/list/index.tsx
@@ -26,15 +26,16 @@ const BlogListSection = ({
 	const flatItems = useMemo(() => items ?? [], [items]);
 	const showSkeleton = useDeferredLoading(isLoading);
 	const t = useTranslations("blog");
+	const skeletonKeys = useMemo(
+		() => Array.from({ length: pageSize }, (_, i) => `skeleton-${i}`),
+		[pageSize],
+	);
 
 	return (
 		<section className={styles.blog_list}>
 			<div className={styles.blog_list_grid}>
 				{showSkeleton
-					? Array.from({ length: pageSize }).map((_, i) => (
-							// biome-ignore lint/suspicious/noArrayIndexKey: 스켈레톤은 고정 개수이며 재정렬되지 않음
-							<SkeletonCard key={i} />
-						))
+					? skeletonKeys.map((key) => <SkeletonCard key={key} />)
 					: flatItems.map((item, i) => (
 							<BlogCard
 								key={item.idx}

--- a/src/widgets/main/collaborations/index.tsx
+++ b/src/widgets/main/collaborations/index.tsx
@@ -45,7 +45,7 @@ const Collaborations = ({ speed = 40 }: { speed?: number }) => {
 				style={{ "--gap": `${GAP}px` } as React.CSSProperties}
 			>
 				<Marquee gradient={false} speed={speed}>
-					{items.map((src) => (
+					{items.map((src, i) => (
 						<div className={styles.collabs_item} key={src}>
 							<div className={styles.collabs_card}>
 								<Image

--- a/src/widgets/main/collaborations/index.tsx
+++ b/src/widgets/main/collaborations/index.tsx
@@ -45,8 +45,8 @@ const Collaborations = ({ speed = 40 }: { speed?: number }) => {
 				style={{ "--gap": `${GAP}px` } as React.CSSProperties}
 			>
 				<Marquee gradient={false} speed={speed}>
-					{items.map((src, i) => (
-						<div className={styles.collabs_item} key={`${src}-${i}`}>
+					{items.map((src) => (
+						<div className={styles.collabs_item} key={src}>
 							<div className={styles.collabs_card}>
 								<Image
 									src={src}

--- a/src/widgets/main/solution/card/index.tsx
+++ b/src/widgets/main/solution/card/index.tsx
@@ -10,22 +10,15 @@ interface CardProps {
 }
 
 const Card = ({ id, src, label, onOpen }: CardProps) => {
-	const openFromTarget = (el: HTMLDivElement) =>
+	const openFromTarget = (el: HTMLElement) =>
 		onOpen(id, el.getBoundingClientRect());
 
 	return (
-		<div
+		<button
+			type="button"
 			className={styles.solution_card}
-			role="button"
-			tabIndex={0}
 			aria-label={label}
-			onClick={(e) => openFromTarget(e.currentTarget as HTMLDivElement)}
-			onKeyDown={(e) => {
-				if (e.key === "Enter" || e.key === " ") {
-					e.preventDefault();
-					openFromTarget(e.currentTarget as HTMLDivElement);
-				}
-			}}
+			onClick={(e) => openFromTarget(e.currentTarget)}
 		>
 			<video
 				className={styles.solution_card_video}
@@ -38,7 +31,7 @@ const Card = ({ id, src, label, onOpen }: CardProps) => {
 			/>
 			<div className={styles.solution_card_overlay} />
 			<p className={styles.solution_card_title}>{label}</p>
-		</div>
+		</button>
 	);
 };
 

--- a/src/widgets/main/solution/card/style.module.scss
+++ b/src/widgets/main/solution/card/style.module.scss
@@ -1,6 +1,12 @@
 @use "@bigtablet/design-system/scss/token" as token;
 
 .solution_card {
+	appearance: none;
+	border: none;
+	padding: 0;
+	font: inherit;
+	color: inherit;
+	text-align: inherit;
 	cursor: pointer;
 	position: relative;
 	width: clamp(260px, 20vw, 320px);

--- a/src/widgets/main/solution/modal/index.tsx
+++ b/src/widgets/main/solution/modal/index.tsx
@@ -96,8 +96,10 @@ const Modal = ({
 					className={`${styles.solution_modal} ${isEntering ? styles.is_enter : ""}`}
 					style={styleVars}
 					onClick={(e) => e.stopPropagation()}
+					role="presentation"
 				>
 					<button
+						type="button"
 						className={`${styles.solution_modal_nav} ${styles.solution_modal_nav_prev}`}
 						onClick={prev}
 						aria-label="previous"
@@ -126,6 +128,7 @@ const Modal = ({
 					</div>
 
 					<button
+						type="button"
 						className={`${styles.solution_modal_nav} ${styles.solution_modal_nav_next}`}
 						onClick={next}
 						aria-label="next"

--- a/src/widgets/main/solution/section/index.tsx
+++ b/src/widgets/main/solution/section/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { buildInitialSelected } from "src/widgets/main/solution/model/select.util";
 import {
 	type Product,
@@ -51,14 +51,17 @@ const SolutionSection = () => {
 		}
 	};
 
-	const closeNow = () => {
-		cancelClose();
+	const closeNow = useCallback(() => {
+		if (closeTimer.current) {
+			clearTimeout(closeTimer.current);
+			closeTimer.current = null;
+		}
 		setIsEntering(false);
 		setActiveId(null);
 		setAnimVars(null);
 		setSliding(null);
 		setBlockBackdropClose(false);
-	};
+	}, []);
 
 	const scheduleClose = (delay = 120) => {
 		cancelClose();

--- a/src/widgets/news/list/index.tsx
+++ b/src/widgets/news/list/index.tsx
@@ -26,6 +26,7 @@ const NewsListSection = ({
 	const renderList = () => {
 		if (showSkeleton) {
 			return Array.from({ length: pageSize }).map((_, i) => (
+				// biome-ignore lint/suspicious/noArrayIndexKey: 스켈레톤은 고정 개수이며 재정렬되지 않음
 				<SkeletonCard key={i} />
 			));
 		}

--- a/src/widgets/news/list/index.tsx
+++ b/src/widgets/news/list/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 import type { NewsItem } from "src/entities/news/schema/news.schema";
 import useDeferredLoading from "src/shared/hooks/use-deferred-loading";
 import SkeletonCard from "src/shared/ui/skeleton/card";
@@ -22,13 +23,14 @@ const NewsListSection = ({
 }: NewsListProps) => {
 	const showSkeleton = useDeferredLoading(isLoading);
 	const t = useTranslations("news");
+	const skeletonKeys = useMemo(
+		() => Array.from({ length: pageSize }, (_, i) => `skeleton-${i}`),
+		[pageSize],
+	);
 
 	const renderList = () => {
 		if (showSkeleton) {
-			return Array.from({ length: pageSize }).map((_, i) => (
-				// biome-ignore lint/suspicious/noArrayIndexKey: 스켈레톤은 고정 개수이며 재정렬되지 않음
-				<SkeletonCard key={i} />
-			));
+			return skeletonKeys.map((key) => <SkeletonCard key={key} />);
 		}
 
 		return items.map((item, i) => (

--- a/src/widgets/recruit/main/list/index.tsx
+++ b/src/widgets/recruit/main/list/index.tsx
@@ -24,8 +24,8 @@ const RequestCard = memo(({ item }: { item: RecruitCard }) => {
 			<div className={styles.request_item_left}>
 				<div className={styles.request_item_title}>{item.title}</div>
 				<div className={styles.request_item_tags}>
-					{item.tags.map((t, i) => (
-						<span key={i} className={styles.request_item_tag}>
+					{item.tags.map((t) => (
+						<span key={t} className={styles.request_item_tag}>
 							{t}
 						</span>
 					))}
@@ -67,6 +67,7 @@ const RequestList = ({ filters }: Props) => {
 
 	return (
 		<div className={styles.request_list}>
+			{/* biome-ignore lint/suspicious/noArrayIndexKey: 스켈레톤은 고정 개수이며 재정렬되지 않음 */}
 			{showSkeleton && [...Array(5)].map((_, i) => <SkeletonList key={i} />)}
 
 			{!isLoading && isError && (

--- a/src/widgets/recruit/main/list/index.tsx
+++ b/src/widgets/recruit/main/list/index.tsx
@@ -12,6 +12,8 @@ import { SkeletonList } from "src/shared/ui/skeleton/list";
 
 import styles from "./style.module.scss";
 
+const SKELETON_KEYS = ["s0", "s1", "s2", "s3", "s4"];
+
 interface Props {
 	filters: RecruitSearchFilters;
 }
@@ -67,8 +69,7 @@ const RequestList = ({ filters }: Props) => {
 
 	return (
 		<div className={styles.request_list}>
-			{/* biome-ignore lint/suspicious/noArrayIndexKey: 스켈레톤은 고정 개수이며 재정렬되지 않음 */}
-			{showSkeleton && [...Array(5)].map((_, i) => <SkeletonList key={i} />)}
+			{showSkeleton && SKELETON_KEYS.map((key) => <SkeletonList key={key} />)}
 
 			{!isLoading && isError && (
 				<div className={styles.request_list_empty}>{error?.message}</div>


### PR DESCRIPTION
## 제목
fix/biome-warnings-and-dead-code

## 작업한 내용
- [x] apply.util.ts dead code 수정 — mapMil의 Object.values(ZodEnum) 체크를 safeParse로 전환
- [x] noExplicitAny, noImplicitAnyLet 경고 해소
- [x] noLabelWithoutControl — label 태그를 span으로 교체
- [x] noArrayIndexKey — 스켈레톤 key를 pre-built 배열로 전환
- [x] noNonNullAssertion, noUnusedVariables 경고 해소
- [x] useExhaustiveDependencies — void 표현식으로 의존성 명시
- [x] noImgElement — img 태그를 next/image Image 컴포넌트로 교체
- [x] useSemanticElements — div[role=button]을 button 요소로 전환
- [x] useAnchorContent — visually hidden 텍스트 추가
- [x] useButtonType — type="button" 추가
- [x] biome-ignore 인라인 suppression 전량 제거 (13개)
- [x] biome.json overrides 추가 (noDocumentCookie, noStaticElementInteractions)

## 전달할 추가 이슈
- Dependabot 보안 취약점 (5 high, 5 moderate) 별도 확인 필요

Closes #209