### PR TITLE
test/e2e-playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,39 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: validate
+    env:
+      NEXT_PUBLIC_SERVER_URL: https://placeholder.test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: pnpm e2e
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ yarn.lock
 
 # test
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/

--- a/e2e/blog-news.spec.ts
+++ b/e2e/blog-news.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("blog page", () => {
+	test("blog list page loads", async ({ page }) => {
+		await page.goto("/blog");
+		await expect(page.locator("main")).toBeVisible();
+	});
+});
+
+test.describe("news page", () => {
+	test("news list page loads", async ({ page }) => {
+		await page.goto("/news");
+		await expect(page.locator("main")).toBeVisible();
+	});
+});

--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("internationalization", () => {
+	test("default locale renders content", async ({ page }) => {
+		await page.goto("/main");
+		await expect(page.locator("body")).not.toBeEmpty();
+	});
+
+	test("korean locale renders korean content", async ({ page, context }) => {
+		await context.addCookies([
+			{ name: "NEXT_LOCALE", value: "ko", url: "http://localhost:3000" },
+		]);
+		await page.goto("/main");
+		await expect(page.locator("body")).not.toBeEmpty();
+	});
+
+	test("english locale renders english content", async ({ page, context }) => {
+		await context.addCookies([
+			{ name: "NEXT_LOCALE", value: "en", url: "http://localhost:3000" },
+		]);
+		await page.goto("/main");
+		await expect(page.locator("body")).not.toBeEmpty();
+	});
+
+	test("legacy /en/ prefix redirects to /", async ({ page }) => {
+		const response = await page.goto("/en/main");
+		expect(response?.url()).not.toContain("/en/");
+	});
+
+	test("legacy /ko/ prefix redirects to /", async ({ page }) => {
+		const response = await page.goto("/ko/main");
+		expect(response?.url()).not.toContain("/ko/");
+	});
+});

--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -3,23 +3,31 @@ import { expect, test } from "@playwright/test";
 test.describe("internationalization", () => {
 	test("default locale renders content", async ({ page }) => {
 		await page.goto("/main");
-		await expect(page.locator("body")).not.toBeEmpty();
+		await expect(page.locator("main")).toBeVisible();
 	});
 
-	test("korean locale renders korean content", async ({ page, context }) => {
+	test("korean locale renders korean content", async ({
+		page,
+		context,
+		baseURL,
+	}) => {
 		await context.addCookies([
-			{ name: "NEXT_LOCALE", value: "ko", url: "http://localhost:3000" },
+			{ name: "NEXT_LOCALE", value: "ko", url: baseURL! },
 		]);
 		await page.goto("/main");
-		await expect(page.locator("body")).not.toBeEmpty();
+		await expect(page.locator("main")).toBeVisible();
 	});
 
-	test("english locale renders english content", async ({ page, context }) => {
+	test("english locale renders english content", async ({
+		page,
+		context,
+		baseURL,
+	}) => {
 		await context.addCookies([
-			{ name: "NEXT_LOCALE", value: "en", url: "http://localhost:3000" },
+			{ name: "NEXT_LOCALE", value: "en", url: baseURL! },
 		]);
 		await page.goto("/main");
-		await expect(page.locator("body")).not.toBeEmpty();
+		await expect(page.locator("main")).toBeVisible();
 	});
 
 	test("legacy /en/ prefix redirects to /", async ({ page }) => {

--- a/e2e/main.spec.ts
+++ b/e2e/main.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("main page", () => {
+	test("/ redirects to /main", async ({ page }) => {
+		const response = await page.goto("/");
+		expect(response?.url()).toContain("/main");
+	});
+
+	test("renders banner section", async ({ page }) => {
+		await page.goto("/main");
+		await expect(page.locator("main")).toBeVisible();
+	});
+
+	test("renders footer", async ({ page }) => {
+		await page.goto("/main");
+		await expect(page.locator("footer")).toBeVisible();
+	});
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("header navigation", () => {
+	test("navigates to recruit page", async ({ page }) => {
+		await page.goto("/main");
+		await page.click('a[href="/recruit"]');
+		await expect(page).toHaveURL(/\/recruit/);
+	});
+
+	test("navigates to blog page", async ({ page }) => {
+		await page.goto("/main");
+		await page.click('a[href="/blog"]');
+		await expect(page).toHaveURL(/\/blog/);
+	});
+
+	test("navigates to news page", async ({ page }) => {
+		await page.goto("/main");
+		await page.click('a[href="/news"]');
+		await expect(page).toHaveURL(/\/news/);
+	});
+
+	test("navigates to about page", async ({ page }) => {
+		await page.goto("/main");
+		await page.click('a[href="/about"]');
+		await expect(page).toHaveURL(/\/about/);
+	});
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -3,25 +3,25 @@ import { expect, test } from "@playwright/test";
 test.describe("header navigation", () => {
 	test("navigates to recruit page", async ({ page }) => {
 		await page.goto("/main");
-		await page.click('a[href="/recruit"]');
+		await page.getByRole("link", { name: "Recruit" }).click();
 		await expect(page).toHaveURL(/\/recruit/);
 	});
 
 	test("navigates to blog page", async ({ page }) => {
 		await page.goto("/main");
-		await page.click('a[href="/blog"]');
+		await page.getByRole("link", { name: "Blog" }).click();
 		await expect(page).toHaveURL(/\/blog/);
 	});
 
 	test("navigates to news page", async ({ page }) => {
 		await page.goto("/main");
-		await page.click('a[href="/news"]');
+		await page.getByRole("link", { name: "News" }).click();
 		await expect(page).toHaveURL(/\/news/);
 	});
 
 	test("navigates to about page", async ({ page }) => {
 		await page.goto("/main");
-		await page.click('a[href="/about"]');
+		await page.getByRole("link", { name: "About Us" }).click();
 		await expect(page).toHaveURL(/\/about/);
 	});
 });

--- a/e2e/recruit.spec.ts
+++ b/e2e/recruit.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("recruit pages", () => {
+	test("recruit list page loads", async ({ page }) => {
+		await page.goto("/recruit");
+		await expect(page.locator("main")).toBeVisible();
+	});
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage",
 		"type-check": "tsc --noEmit",
+		"e2e": "playwright test",
+		"e2e:ui": "playwright test --ui",
 		"analyze": "ANALYZE=true next build --turbopack",
 		"prepare": "husky"
 	},
@@ -49,6 +51,7 @@
 		"@commitlint/cli": "^20.5.0",
 		"@commitlint/core": "^20.5.0",
 		"@next/bundle-analyzer": "^16.2.2",
+		"@playwright/test": "^1.59.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+	testDir: "./e2e",
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: "html",
+	use: {
+		baseURL: "http://localhost:3000",
+		trace: "on-first-retry",
+	},
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
+	],
+	webServer: {
+		command: "pnpm build && pnpm start",
+		url: "http://localhost:3000",
+		reuseExistingServer: !process.env.CI,
+		timeout: 120_000,
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@bigtablet/design-system':
         specifier: 1.22.0
-        version: 1.22.0(lucide-react@1.7.0(react@19.2.4))(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 1.22.0(lucide-react@1.7.0(react@19.2.4))(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@gsap/react':
         specifier: ^2.1.2
         version: 2.1.2(gsap@3.14.2)(react@19.2.4)
@@ -22,7 +22,7 @@ importers:
         version: 1.9.1
       '@sentry/nextjs':
         specifier: ^10.47.0
-        version: 10.47.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(webpack@5.105.4)
+        version: 10.47.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(webpack@5.105.4)
       '@tanstack/react-query':
         specifier: ^5.96.1
         version: 5.96.1(react@19.2.4)
@@ -49,10 +49,10 @@ importers:
         version: 1.7.0(react@19.2.4)
       next:
         specifier: 16.2.2
-        version: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
+        version: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
       next-intl:
         specifier: ^4.9.0
-        version: 4.9.0(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(typescript@6.0.2)
+        version: 4.9.0(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(typescript@6.0.2)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -99,6 +99,9 @@ importers:
       '@next/bundle-analyzer':
         specifier: ^16.2.2
         version: 16.2.2
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -1266,6 +1269,11 @@ packages:
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -2352,6 +2360,11 @@ packages:
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2976,6 +2989,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   po-parser@2.1.1:
     resolution: {integrity: sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==}
@@ -3711,13 +3734,13 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bigtablet/design-system@1.22.0(lucide-react@1.7.0(react@19.2.4))(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@bigtablet/design-system@1.22.0(lucide-react@1.7.0(react@19.2.4))(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       lucide-react: 1.7.0(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      next: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
+      next: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
 
   '@biomejs/biome@2.4.10':
     optionalDependencies:
@@ -4617,6 +4640,10 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@polka/url@1.0.0-next.29': {}
 
   '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
@@ -4812,7 +4839,7 @@ snapshots:
 
   '@sentry/core@10.47.0': {}
 
-  '@sentry/nextjs@10.47.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(webpack@5.105.4)':
+  '@sentry/nextjs@10.47.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(webpack@5.105.4)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -4825,7 +4852,7 @@ snapshots:
       '@sentry/react': 10.47.0(react@19.2.4)
       '@sentry/vercel-edge': 10.47.0
       '@sentry/webpack-plugin': 5.1.1(webpack@5.105.4)
-      next: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
+      next: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
       rollup: 4.60.1
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -5674,6 +5701,9 @@ snapshots:
 
   forwarded-parse@2.1.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6395,14 +6425,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.9.0: {}
 
-  next-intl@4.9.0(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(typescript@6.0.2):
+  next-intl@4.9.0(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0))(react@19.2.4)(typescript@6.0.2):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.2
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.21
       icu-minify: 4.9.0
       negotiator: 1.0.0
-      next: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
+      next: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0)
       next-intl-swc-plugin-extractor: 4.9.0
       po-parser: 2.1.1
       react: 19.2.4
@@ -6412,7 +6442,7 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0):
+  next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.98.0):
     dependencies:
       '@next/env': 16.2.2
       '@swc/helpers': 0.5.15
@@ -6432,6 +6462,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.2.2
       '@next/swc-win32-x64-msvc': 16.2.2
       '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.59.1
       babel-plugin-react-compiler: 1.0.0
       sass: 1.98.0
       sharp: 0.34.5
@@ -6512,6 +6543,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   po-parser@2.1.1: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
 		environment: "jsdom",
 		setupFiles: ["./vitest.setup.ts"],
 		globals: true,
+		exclude: ["e2e/**", "node_modules/**"],
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "json", "json-summary", "html"],


### PR DESCRIPTION
## 제목
test/e2e-playwright

## 작업한 내용
- [x] Playwright E2E 테스트 인프라 구축 (Chromium only)
- [x] 메인 페이지 테스트 (리다이렉트, 렌더링)
- [x] 헤더 네비게이션 테스트 (recruit, blog, news, about)
- [x] i18n 로케일 전환 테스트 (쿠키 기반, 레거시 prefix 리다이렉트)
- [x] 채용/블로그/뉴스 페이지 로드 테스트
- [x] CI에 e2e job 추가 (validate 이후 실행, report 아티팩트 업로드)
- [x] Vitest에서 e2e 디렉토리 제외

## 전달할 추가 이슈
- 없음