### PR TITLE
style/refactor-naming-jsdoc-tests

### DIFF
--- a/src/app/(i18n)/blog/page.tsx
+++ b/src/app/(i18n)/blog/page.tsx
@@ -26,10 +26,10 @@ const BlogPage = () => {
 	const totalPages = data?.hasNext ? page + 1 : page;
 
 	const handlePageChange = (nextPage: number) => {
-		const params = new URLSearchParams(sp.toString());
-		params.set("page", String(nextPage));
-		params.set("size", String(size));
-		router.push(`${pathname}?${params.toString()}`);
+		const searchParameters = new URLSearchParams(sp.toString());
+		searchParameters.set("page", String(nextPage));
+		searchParameters.set("size", String(size));
+		router.push(`${pathname}?${searchParameters.toString()}`);
 	};
 
 	return (

--- a/src/app/(i18n)/layout.tsx
+++ b/src/app/(i18n)/layout.tsx
@@ -10,8 +10,10 @@ export default async function LocaleLayout({
 }: {
 	children: ReactNode;
 }) {
-	const c = (await cookies()).get("NEXT_LOCALE")?.value?.toLowerCase();
-	const locale = c === "en" ? "en" : "ko"; // 기본 ko
+	const localeValue = (await cookies())
+		.get("NEXT_LOCALE")
+		?.value?.toLowerCase();
+	const locale = localeValue === "en" ? "en" : "ko"; // 기본 ko
 	const messages = (await import(`../../../messages/${locale}.json`)).default;
 
 	return (

--- a/src/app/(i18n)/news/page.tsx
+++ b/src/app/(i18n)/news/page.tsx
@@ -28,9 +28,9 @@ const NewsPage = () => {
 
 	const handleChangePage = (nextPage: number) => {
 		const clamped = Math.max(1, nextPage);
-		const params = new URLSearchParams(searchParams.toString());
-		params.set("page", String(clamped));
-		router.push(`${pathname}?${params.toString()}`);
+		const searchParameters = new URLSearchParams(searchParams.toString());
+		searchParameters.set("page", String(clamped));
+		router.push(`${pathname}?${searchParameters.toString()}`);
 	};
 
 	return (

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -42,16 +42,16 @@ const GlobalError = ({
 	const handleRetry = useCallback(() => {
 		if (isCooling || isMaxRetry) return;
 
-		setRetryCount((prev) => prev + 1);
+		setRetryCount((previous) => previous + 1);
 		setCooldown(COOLDOWN_SEC);
 
 		timerRef.current = setInterval(() => {
-			setCooldown((prev) => {
-				if (prev <= 1) {
+			setCooldown((previous) => {
+				if (previous <= 1) {
 					clearInterval(timerRef.current);
 					return 0;
 				}
-				return prev - 1;
+				return previous - 1;
 			});
 		}, 1000);
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,8 +22,8 @@ export default async function RootLayout({
 	children: React.ReactNode;
 }) {
 	const store = await cookies();
-	const val = store.get("NEXT_LOCALE")?.value;
-	const locale = (val === "en" ? "en" : "ko") as "en" | "ko";
+	const value = store.get("NEXT_LOCALE")?.value;
+	const locale = (value === "en" ? "en" : "ko") as "en" | "ko";
 
 	let messages: Awaited<ReturnType<typeof getMessages>> | undefined;
 	try {

--- a/src/entities/about/history/util/group.ts
+++ b/src/entities/about/history/util/group.ts
@@ -1,27 +1,39 @@
 import type { HistorySchema } from "src/entities/about/history/schema/history.schema";
 
+/** 연혁 항목에서 표시에 필요한 필드만 추출한 타입 */
 export type YearEntry = Pick<
 	HistorySchema,
 	"id" | "title" | "description" | "dateLabel"
 >;
 
+/** 연도별로 그룹핑된 연혁 데이터 */
 export interface YearGroup {
 	year: number;
 	list: YearEntry[];
 }
 
+/**
+ * @description 연혁 데이터를 연도별로 그룹핑한다. 최신 연도가 먼저 온다.
+ *
+ * @param items - 원본 연혁 데이터 배열
+ * @returns 연도별 그룹 배열 (내림차순)
+ *
+ * @example
+ * buildYearGroups([{ year: 2024, ... }, { year: 2023, ... }])
+ * // [{ year: 2024, list: [...] }, { year: 2023, list: [...] }]
+ */
 export const buildYearGroups = (items: HistorySchema[]): YearGroup[] => {
 	const byYear = new Map<number, YearEntry[]>();
 
-	for (const it of items) {
-		const arr = byYear.get(it.year) ?? [];
-		arr.push({
-			id: it.id,
-			title: it.title,
-			description: it.description,
-			dateLabel: it.dateLabel,
+	for (const historyItem of items) {
+		const yearEntries = byYear.get(historyItem.year) ?? [];
+		yearEntries.push({
+			id: historyItem.id,
+			title: historyItem.title,
+			description: historyItem.description,
+			dateLabel: historyItem.dateLabel,
 		});
-		byYear.set(it.year, arr);
+		byYear.set(historyItem.year, yearEntries);
 	}
 
 	return [...byYear.entries()]
@@ -29,5 +41,13 @@ export const buildYearGroups = (items: HistorySchema[]): YearGroup[] => {
 		.map(([year, list]) => ({ year, list }));
 };
 
+/**
+ * @description 연도 그룹 배열에서 연도 숫자만 추출한다.
+ *
+ * @param groups - 연도별 그룹 배열
+ * @returns 연도 배열
+ *
+ * @see {@link buildYearGroups}
+ */
 export const yearsFromGroups = (groups: YearGroup[]) =>
-	groups.map((g) => g.year);
+	groups.map((group) => group.year);

--- a/src/entities/blog/__tests__/blog.api.test.ts
+++ b/src/entities/blog/__tests__/blog.api.test.ts
@@ -1,0 +1,67 @@
+import { HttpResponse, http } from "msw";
+import { server } from "src/test/msw/server";
+import { describe, expect, it } from "vitest";
+import {
+	getBlogApi,
+	getBlogDetailApi,
+	patchBlogViewApi,
+} from "../api/blog.api";
+
+describe("getBlogApi", () => {
+	it("블로그 목록을 정상 조회한다", async () => {
+		const result = await getBlogApi({ page: 1, size: 10 });
+		expect(Array.isArray(result)).toBe(true);
+		expect(result.length).toBeGreaterThan(0);
+		expect(result[0]).toHaveProperty("idx");
+	});
+
+	it("빈 데이터 시 빈 배열을 반환한다", async () => {
+		server.use(
+			http.get("*/blog/list", () =>
+				HttpResponse.json({ status: 200, message: "ok", data: null }),
+			),
+		);
+		const result = await getBlogApi({ page: 1, size: 10 });
+		expect(result).toEqual([]);
+	});
+
+	it("AbortSignal로 요청을 취소할 수 있다", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		await expect(
+			getBlogApi({ page: 1, size: 10 }, controller.signal),
+		).rejects.toThrow();
+	});
+
+	it("서버 에러 시 예외를 throw한다", async () => {
+		server.use(
+			http.get("*/blog/list", () => HttpResponse.json(null, { status: 500 })),
+		);
+		await expect(getBlogApi({ page: 1, size: 10 })).rejects.toThrow();
+	});
+});
+
+describe("getBlogDetailApi", () => {
+	it("블로그 상세를 정상 조회한다", async () => {
+		const result = await getBlogDetailApi(1);
+		expect(result).toBeDefined();
+		expect(result.idx).toBe(1);
+	});
+
+	it("빈 응답 시 에러를 throw한다", async () => {
+		server.use(
+			http.get("*/blog", () =>
+				HttpResponse.json({ status: 200, message: "ok", data: null }),
+			),
+		);
+		await expect(getBlogDetailApi(1)).rejects.toThrow("Empty response");
+	});
+});
+
+describe("patchBlogViewApi", () => {
+	it("조회수 증가 요청이 정상 처리된다", async () => {
+		const result = await patchBlogViewApi(1);
+		expect(result).toBeDefined();
+		expect(result.status).toBe(200);
+	});
+});

--- a/src/entities/blog/__tests__/blog.schema.test.ts
+++ b/src/entities/blog/__tests__/blog.schema.test.ts
@@ -45,16 +45,16 @@ describe("blogItemSchema", () => {
 
 describe("blogListResponseSchema", () => {
 	it("목록 응답을 파싱한다", () => {
-		const res = { status: 200, message: "ok", data: [validItem] };
-		const parsed = blogListResponseSchema.parse(res);
+		const response = { status: 200, message: "ok", data: [validItem] };
+		const parsed = blogListResponseSchema.parse(response);
 		expect(parsed.data).toHaveLength(1);
 	});
 });
 
 describe("blogDetailResponseSchema", () => {
 	it("상세 응답을 파싱한다", () => {
-		const res = { status: 200, message: "ok", data: validItem };
-		const parsed = blogDetailResponseSchema.parse(res);
+		const response = { status: 200, message: "ok", data: validItem };
+		const parsed = blogDetailResponseSchema.parse(response);
 		expect(parsed.data?.idx).toBe(1);
 	});
 });

--- a/src/entities/blog/api/blog.api.ts
+++ b/src/entities/blog/api/blog.api.ts
@@ -8,7 +8,18 @@ import {
 import { getParsed, patchParsed } from "src/shared/libs/api/zod";
 import type { ListSchema } from "src/shared/schema/list/list.schema";
 
-// 리스트
+/**
+ * @author 박상민
+ *
+ * @description 블로그 목록을 페이지네이션으로 조회한다.
+ * @endpoint GET /blog/list
+ * @auth Unnecessary
+ * @permission Unnecessary
+ *
+ * @param parameters - 페이지 번호와 페이지 크기
+ * @param signal - 요청 취소를 위한 AbortSignal
+ * @returns 블로그 아이템 배열 (빈 데이터 시 빈 배열)
+ */
 export const getBlogApi = async (
 	{ page, size }: ListSchema,
 	signal?: AbortSignal,
@@ -19,18 +30,40 @@ export const getBlogApi = async (
 	}).then((response) => response.data ?? []);
 };
 
-// 상세
-export const getBlogDetailApi = async (idx: number, signal?: AbortSignal) =>
+/**
+ * @author 박상민
+ *
+ * @description 블로그 상세 정보를 조회한다.
+ * @endpoint GET /blog?idx={index}
+ * @auth Unnecessary
+ * @permission Unnecessary
+ *
+ * @param index - 블로그 게시글 고유 번호
+ * @param signal - 요청 취소를 위한 AbortSignal
+ * @returns 블로그 상세 데이터
+ * @throws 응답 데이터가 비어있으면 "Empty response" 에러
+ */
+export const getBlogDetailApi = async (index: number, signal?: AbortSignal) =>
 	getParsed("/blog", blogDetailResponseSchema, {
-		params: { idx },
+		params: { idx: index },
 		signal,
 	}).then((response: BlogDetailResponse) => {
 		if (!response.data) throw new Error("Empty response");
 		return response.data;
 	});
 
-// 조회수 증가
-export const patchBlogViewApi = async (idx: number) =>
-	patchParsed("/blog", blogOkResponseSchema, null, { params: { idx } }).then(
-		(response: BlogOkResponse) => response,
-	);
+/**
+ * @author 박상민
+ *
+ * @description 블로그 조회수를 1 증가시킨다.
+ * @endpoint PATCH /blog?idx={index}
+ * @auth Unnecessary
+ * @permission Unnecessary
+ *
+ * @param index - 블로그 게시글 고유 번호
+ * @returns 성공 응답 객체
+ */
+export const patchBlogViewApi = async (index: number) =>
+	patchParsed("/blog", blogOkResponseSchema, null, {
+		params: { idx: index },
+	}).then((response: BlogOkResponse) => response);

--- a/src/entities/blog/api/blog.api.ts
+++ b/src/entities/blog/api/blog.api.ts
@@ -16,7 +16,7 @@ import type { ListSchema } from "src/shared/schema/list/list.schema";
  * @auth Unnecessary
  * @permission Unnecessary
  *
- * @param parameters - 페이지 번호와 페이지 크기
+ * @param {ListSchema} options - 페이지 번호와 페이지 크기
  * @param signal - 요청 취소를 위한 AbortSignal
  * @returns 블로그 아이템 배열 (빈 데이터 시 빈 배열)
  */

--- a/src/entities/news/__tests__/news.api.test.ts
+++ b/src/entities/news/__tests__/news.api.test.ts
@@ -1,0 +1,37 @@
+import { HttpResponse, http } from "msw";
+import { server } from "src/test/msw/server";
+import { describe, expect, it } from "vitest";
+import { getNewsApi } from "../api/news.api";
+
+describe("getNewsApi", () => {
+	it("뉴스 목록을 정상 조회한다", async () => {
+		const result = await getNewsApi({ page: 1, size: 10 });
+		expect(result).toBeDefined();
+		expect(result.data).toBeDefined();
+	});
+
+	it("빈 데이터 시 null data를 반환한다", async () => {
+		server.use(
+			http.get("*/news/list", () =>
+				HttpResponse.json({ status: 200, message: "ok", data: null }),
+			),
+		);
+		const result = await getNewsApi({ page: 1, size: 10 });
+		expect(result.data).toBeNull();
+	});
+
+	it("AbortSignal로 요청을 취소할 수 있다", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		await expect(
+			getNewsApi({ page: 1, size: 10 }, controller.signal),
+		).rejects.toThrow();
+	});
+
+	it("서버 에러 시 예외를 throw한다", async () => {
+		server.use(
+			http.get("*/news/list", () => HttpResponse.json(null, { status: 500 })),
+		);
+		await expect(getNewsApi({ page: 1, size: 10 })).rejects.toThrow();
+	});
+});

--- a/src/entities/news/__tests__/news.schema.test.ts
+++ b/src/entities/news/__tests__/news.schema.test.ts
@@ -28,8 +28,8 @@ describe("newsItemSchema", () => {
 
 describe("newsListResponseSchema", () => {
 	it("목록 응답을 파싱한다", () => {
-		const res = { status: 200, message: "ok", data: [validItem] };
-		const parsed = newsListResponseSchema.parse(res);
+		const response = { status: 200, message: "ok", data: [validItem] };
+		const parsed = newsListResponseSchema.parse(response);
 		expect(parsed.data).toHaveLength(1);
 	});
 });

--- a/src/entities/news/api/news.api.ts
+++ b/src/entities/news/api/news.api.ts
@@ -13,7 +13,7 @@ import type { ListSchema } from "src/shared/schema/list/list.schema";
  * @auth Unnecessary
  * @permission Unnecessary
  *
- * @param parameters - 페이지 번호와 페이지 크기
+ * @param {ListSchema} options - 페이지 번호와 페이지 크기
  * @param signal - 요청 취소를 위한 AbortSignal
  * @returns 뉴스 목록 응답 (data 배열 포함)
  */

--- a/src/entities/news/api/news.api.ts
+++ b/src/entities/news/api/news.api.ts
@@ -5,7 +5,18 @@ import {
 import { getParsed } from "src/shared/libs/api/zod";
 import type { ListSchema } from "src/shared/schema/list/list.schema";
 
-// 목록
+/**
+ * @author 박상민
+ *
+ * @description 뉴스 목록을 페이지네이션으로 조회한다.
+ * @endpoint GET /news/list
+ * @auth Unnecessary
+ * @permission Unnecessary
+ *
+ * @param parameters - 페이지 번호와 페이지 크기
+ * @param signal - 요청 취소를 위한 AbortSignal
+ * @returns 뉴스 목록 응답 (data 배열 포함)
+ */
 export const getNewsApi = async (
 	{ page, size }: ListSchema,
 	signal?: AbortSignal,

--- a/src/entities/recruit/__tests__/merge.test.ts
+++ b/src/entities/recruit/__tests__/merge.test.ts
@@ -32,38 +32,38 @@ describe("intersectByIdx", () => {
 	});
 
 	it("두 배열의 교집합만 반환", () => {
-		const a = [makeItem(1), makeItem(2), makeItem(3)];
-		const b = [makeItem(2), makeItem(3), makeItem(4)];
-		const result = intersectByIdx([a, b]);
-		const idxs = result.map((r) => r.idx);
+		const firstList = [makeItem(1), makeItem(2), makeItem(3)];
+		const secondList = [makeItem(2), makeItem(3), makeItem(4)];
+		const result = intersectByIdx([firstList, secondList]);
+		const idxs = result.map((recruitItem) => recruitItem.idx);
 		expect(idxs.sort()).toEqual([2, 3]);
 	});
 
 	it("세 배열 모두에 있는 항목만 반환", () => {
-		const a = [makeItem(1), makeItem(2), makeItem(3)];
-		const b = [makeItem(2), makeItem(3)];
-		const c = [makeItem(3), makeItem(4)];
-		const result = intersectByIdx([a, b, c]);
-		expect(result.map((r) => r.idx)).toEqual([3]);
+		const firstList = [makeItem(1), makeItem(2), makeItem(3)];
+		const secondList = [makeItem(2), makeItem(3)];
+		const thirdList = [makeItem(3), makeItem(4)];
+		const result = intersectByIdx([firstList, secondList, thirdList]);
+		expect(result.map((recruitItem) => recruitItem.idx)).toEqual([3]);
 	});
 
 	it("교집합 없으면 빈 배열 반환", () => {
-		const a = [makeItem(1), makeItem(2)];
-		const b = [makeItem(3), makeItem(4)];
-		expect(intersectByIdx([a, b])).toEqual([]);
+		const firstList = [makeItem(1), makeItem(2)];
+		const secondList = [makeItem(3), makeItem(4)];
+		expect(intersectByIdx([firstList, secondList])).toEqual([]);
 	});
 
 	it("결과는 idx 내림차순 정렬", () => {
-		const a = [makeItem(1), makeItem(3), makeItem(5)];
-		const b = [makeItem(1), makeItem(3), makeItem(5)];
-		const result = intersectByIdx([a, b]);
-		expect(result.map((r) => r.idx)).toEqual([5, 3, 1]);
+		const firstList = [makeItem(1), makeItem(3), makeItem(5)];
+		const secondList = [makeItem(1), makeItem(3), makeItem(5)];
+		const result = intersectByIdx([firstList, secondList]);
+		expect(result.map((recruitItem) => recruitItem.idx)).toEqual([5, 3, 1]);
 	});
 
 	it("중복 idx가 있어도 한 번만 카운트", () => {
-		const a = [makeItem(1), makeItem(1)];
-		const b = [makeItem(1)];
-		const result = intersectByIdx([a, b]);
+		const firstList = [makeItem(1), makeItem(1)];
+		const secondList = [makeItem(1)];
+		const result = intersectByIdx([firstList, secondList]);
 		expect(result).toHaveLength(1);
 	});
 });

--- a/src/entities/recruit/__tests__/recruit.api.test.ts
+++ b/src/entities/recruit/__tests__/recruit.api.test.ts
@@ -1,0 +1,69 @@
+import { HttpResponse, http } from "msw";
+import { server } from "src/test/msw/server";
+import { describe, expect, it } from "vitest";
+import { getRecruitDetailApi, getRecruitListApi } from "../api/recruit.api";
+
+describe("getRecruitListApi", () => {
+	it("채용 목록을 정상 조회한다", async () => {
+		const result = await getRecruitListApi({ page: 1, size: 10 });
+		expect(Array.isArray(result)).toBe(true);
+		expect(result.length).toBeGreaterThan(0);
+		expect(result[0]).toHaveProperty("idx");
+	});
+
+	it("빈 데이터 시 빈 배열을 반환한다", async () => {
+		server.use(
+			http.get("*/job/list", () =>
+				HttpResponse.json({ status: 200, message: "ok", data: null }),
+			),
+		);
+		const result = await getRecruitListApi({ page: 1, size: 10 });
+		expect(result).toEqual([]);
+	});
+
+	it("문자열 데이터 시 빈 배열을 반환한다", async () => {
+		server.use(
+			http.get("*/job/list", () =>
+				HttpResponse.json({
+					status: 200,
+					message: "ok",
+					data: "no data",
+				}),
+			),
+		);
+		const result = await getRecruitListApi({ page: 1, size: 10 });
+		expect(result).toEqual([]);
+	});
+
+	it("AbortSignal로 요청을 취소할 수 있다", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		await expect(
+			getRecruitListApi({ page: 1, size: 10, signal: controller.signal }),
+		).rejects.toThrow();
+	});
+
+	it("서버 에러 시 예외를 throw한다", async () => {
+		server.use(
+			http.get("*/job/list", () => HttpResponse.json(null, { status: 500 })),
+		);
+		await expect(getRecruitListApi({ page: 1, size: 10 })).rejects.toThrow();
+	});
+});
+
+describe("getRecruitDetailApi", () => {
+	it("채용 상세를 정상 조회한다", async () => {
+		const result = await getRecruitDetailApi(1);
+		expect(result).toBeDefined();
+		expect(result.idx).toBe(1);
+	});
+
+	it("빈 응답 시 에러를 throw한다", async () => {
+		server.use(
+			http.get("*/job", () =>
+				HttpResponse.json({ status: 200, message: "ok", data: null }),
+			),
+		);
+		await expect(getRecruitDetailApi(1)).rejects.toThrow("Empty response");
+	});
+});

--- a/src/entities/recruit/api/recruit.api.ts
+++ b/src/entities/recruit/api/recruit.api.ts
@@ -8,6 +8,7 @@ import {
 	recruitListResponseSchema,
 } from "../schema/recruit.schema";
 
+/** 채용 공고 검색 필터 인터페이스 */
 export interface RecruitSearchFilters {
 	keyword?: string;
 	job?: string;
@@ -15,7 +16,23 @@ export interface RecruitSearchFilters {
 	career?: string;
 }
 
-/* 목록 + 검색 */
+/**
+ * @author 박상민
+ *
+ * @description 채용 공고 목록을 필터 조건으로 조회한다.
+ * @endpoint GET /job/list
+ * @auth Unnecessary
+ * @permission Unnecessary
+ *
+ * @param options.page - 페이지 번호 (기본 1)
+ * @param options.size - 페이지 크기 (기본 10)
+ * @param options.title - 제목 검색어
+ * @param options.department - 부서 필터
+ * @param options.education - 학력 필터
+ * @param options.recruitType - 채용 유형 필터
+ * @param options.signal - 요청 취소를 위한 AbortSignal
+ * @returns 채용 공고 배열 (빈 데이터 시 빈 배열)
+ */
 export const getRecruitListApi = async ({
 	page = 1,
 	size = 10,
@@ -52,20 +69,43 @@ export const getRecruitListApi = async ({
 	return data;
 };
 
-/* 상세 */
+/**
+ * @author 박상민
+ *
+ * @description 채용 공고 상세 정보를 조회한다.
+ * @endpoint GET /job?idx={index}
+ * @auth Unnecessary
+ * @permission Unnecessary
+ *
+ * @param index - 채용 공고 고유 번호
+ * @param signal - 요청 취소를 위한 AbortSignal
+ * @returns 채용 공고 상세 데이터
+ * @throws 응답 데이터가 비어있으면 "Empty response" 에러
+ */
 export const getRecruitDetailApi = async (
-	idx: number,
+	index: number,
 	signal?: AbortSignal,
 ) => {
 	const { data } = await getParsed("/job", recruitDetailResponseSchema, {
 		signal,
-		params: { idx },
+		params: { idx: index },
 	});
 	if (!data) throw new Error("Empty response");
 	return data;
 };
 
-/** 지원 */
+/**
+ * @author 박상민
+ *
+ * @description 채용 공고에 지원서를 제출한다.
+ * @endpoint POST /recruit
+ * @auth Unnecessary
+ * @permission Unnecessary
+ *
+ * @param body - 지원서 데이터
+ * @param signal - 요청 취소를 위한 AbortSignal
+ * @returns 지원 결과 응답
+ */
 export const postRecruitApplyApi = async (
 	body: RecruitRequest,
 	signal?: AbortSignal,

--- a/src/entities/recruit/util/date/index.ts
+++ b/src/entities/recruit/util/date/index.ts
@@ -41,40 +41,46 @@ const getDdayText = (endDate?: string | null): string => {
 /**
  * @description 채용 공고에서 부서, 학력, 유형, 지역 태그를 추출한다.
  *
- * @param r - 채용 공고 응답 데이터
+ * @param recruitResponse - 채용 공고 응답 데이터
  * @returns 라벨 문자열 배열
  */
-const extractTags = (r: RecruitResponse): string[] => {
+const extractTags = (recruitResponse: RecruitResponse): string[] => {
 	const tags: string[] = [];
-	if (r.department) tags.push(departmentLabel(r.department));
-	if (r.education) tags.push(educationLabel(r.education));
-	if (r.recruitType) tags.push(recruitTypeLabel(r.recruitType));
-	if (r.location) tags.push(locationLabel(r.location));
+	if (recruitResponse.department)
+		tags.push(departmentLabel(recruitResponse.department));
+	if (recruitResponse.education)
+		tags.push(educationLabel(recruitResponse.education));
+	if (recruitResponse.recruitType)
+		tags.push(recruitTypeLabel(recruitResponse.recruitType));
+	if (recruitResponse.location)
+		tags.push(locationLabel(recruitResponse.location));
 	return tags;
 };
 
 /**
  * @description 채용 응답 데이터를 카드 UI용 데이터로 변환한다.
  *
- * @param r - 채용 공고 응답 데이터
+ * @param recruitResponse - 채용 공고 응답 데이터
  * @returns D-Day와 태그가 추가된 카드 데이터
  *
  * @example
  * toRecruitCard(recruitResponse) // { ...response, dday: "D-3", tags: ["IT", "서울"] }
  */
-export const toRecruitCard = (r: RecruitResponse): RecruitCard => ({
-	...r,
-	dday: getDdayText(r.endDate ?? null),
-	tags: extractTags(r),
+export const toRecruitCard = (
+	recruitResponse: RecruitResponse,
+): RecruitCard => ({
+	...recruitResponse,
+	dday: getDdayText(recruitResponse.endDate ?? null),
+	tags: extractTags(recruitResponse),
 });
 
 /**
  * @description 채용 응답 배열을 카드 배열로 일괄 변환한다.
  *
- * @param arr - 채용 공고 응답 배열
+ * @param recruitResponses - 채용 공고 응답 배열
  * @returns 카드 데이터 배열
  *
  * @see {@link toRecruitCard}
  */
-export const toRecruitCards = (arr: RecruitResponse[]) =>
-	arr.map(toRecruitCard);
+export const toRecruitCards = (recruitResponses: RecruitResponse[]) =>
+	recruitResponses.map(toRecruitCard);

--- a/src/entities/recruit/util/date/index.ts
+++ b/src/entities/recruit/util/date/index.ts
@@ -9,8 +9,24 @@ import type {
 	RecruitResponse,
 } from "src/entities/recruit/schema/recruit.schema";
 
+/**
+ * @description 문자열을 Date 객체로 변환한다.
+ *
+ * @param value - 날짜 문자열 또는 null
+ * @returns Date 객체 또는 undefined
+ */
 const toDate = (value?: string | null) => (value ? new Date(value) : undefined);
 
+/**
+ * @description D-Day 텍스트를 계산하여 반환한다.
+ *
+ * @param endDate - 마감일 문자열 (ISO 8601) 또는 null
+ * @returns "D-3", "D-DAY", "마감", "상시" 등의 문자열
+ *
+ * @example
+ * getDdayText("2026-04-05") // "D-3"
+ * getDdayText(null)          // "상시"
+ */
 const getDdayText = (endDate?: string | null): string => {
 	const end = toDate(endDate);
 	if (!end) return "상시";
@@ -22,6 +38,12 @@ const getDdayText = (endDate?: string | null): string => {
 	return `D-${days}`;
 };
 
+/**
+ * @description 채용 공고에서 부서, 학력, 유형, 지역 태그를 추출한다.
+ *
+ * @param r - 채용 공고 응답 데이터
+ * @returns 라벨 문자열 배열
+ */
 const extractTags = (r: RecruitResponse): string[] => {
 	const tags: string[] = [];
 	if (r.department) tags.push(departmentLabel(r.department));
@@ -31,11 +53,28 @@ const extractTags = (r: RecruitResponse): string[] => {
 	return tags;
 };
 
+/**
+ * @description 채용 응답 데이터를 카드 UI용 데이터로 변환한다.
+ *
+ * @param r - 채용 공고 응답 데이터
+ * @returns D-Day와 태그가 추가된 카드 데이터
+ *
+ * @example
+ * toRecruitCard(recruitResponse) // { ...response, dday: "D-3", tags: ["IT", "서울"] }
+ */
 export const toRecruitCard = (r: RecruitResponse): RecruitCard => ({
 	...r,
 	dday: getDdayText(r.endDate ?? null),
 	tags: extractTags(r),
 });
 
+/**
+ * @description 채용 응답 배열을 카드 배열로 일괄 변환한다.
+ *
+ * @param arr - 채용 공고 응답 배열
+ * @returns 카드 데이터 배열
+ *
+ * @see {@link toRecruitCard}
+ */
 export const toRecruitCards = (arr: RecruitResponse[]) =>
 	arr.map(toRecruitCard);

--- a/src/entities/recruit/util/merge/index.ts
+++ b/src/entities/recruit/util/merge/index.ts
@@ -1,28 +1,42 @@
 import type { RecruitResponse } from "src/entities/recruit/schema/recruit.schema";
 
+/**
+ * @description 여러 채용 공고 배열의 교집합을 idx 기준으로 구한다.
+ * 결과는 idx 내림차순으로 정렬된다.
+ *
+ * @param lists - 채용 공고 배열들
+ * @returns 모든 배열에 공통으로 존재하는 채용 공고 배열
+ *
+ * @example
+ * intersectByIdx([[item1, item2], [item2, item3]]) // [item2]
+ */
 export const intersectByIdx = (
 	lists: RecruitResponse[][],
 ): RecruitResponse[] => {
-	const nonEmpty = lists.filter((a) => a?.length);
+	const nonEmpty = lists.filter((list) => list?.length);
 	if (nonEmpty.length === 0) return [];
 	if (nonEmpty.length === 1) return nonEmpty[0];
 
-	const count = new Map<number, RecruitResponse>();
-	const freq = new Map<number, number>();
+	const itemMap = new Map<number, RecruitResponse>();
+	const frequencyMap = new Map<number, number>();
 
-	for (const arr of nonEmpty) {
+	for (const entries of nonEmpty) {
 		const seen = new Set<number>();
-		for (const it of arr) {
-			if (typeof it.idx !== "number") continue;
-			if (seen.has(it.idx)) continue;
-			seen.add(it.idx);
-			if (!count.has(it.idx)) count.set(it.idx, it);
-			freq.set(it.idx, (freq.get(it.idx) ?? 0) + 1);
+		for (const recruitItem of entries) {
+			if (typeof recruitItem.idx !== "number") continue;
+			if (seen.has(recruitItem.idx)) continue;
+			seen.add(recruitItem.idx);
+			if (!itemMap.has(recruitItem.idx))
+				itemMap.set(recruitItem.idx, recruitItem);
+			frequencyMap.set(
+				recruitItem.idx,
+				(frequencyMap.get(recruitItem.idx) ?? 0) + 1,
+			);
 		}
 	}
 	const need = nonEmpty.length;
-	return Array.from(freq.entries())
-		.filter(([, n]) => n === need)
-		.map(([idx]) => count.get(idx) as RecruitResponse)
+	return Array.from(frequencyMap.entries())
+		.filter(([, frequency]) => frequency === need)
+		.map(([idx]) => itemMap.get(idx) as RecruitResponse)
 		.sort((a, b) => (b.idx ?? 0) - (a.idx ?? 0));
 };

--- a/src/entities/talent/__tests__/talent.schema.test.ts
+++ b/src/entities/talent/__tests__/talent.schema.test.ts
@@ -52,7 +52,7 @@ describe("postTalentSchema", () => {
 
 describe("getTalentDetailResponseSchema", () => {
 	it("상세 응답을 파싱한다", () => {
-		const res = {
+		const response = {
 			status: 200,
 			message: "ok",
 			data: {
@@ -64,7 +64,7 @@ describe("getTalentDetailResponseSchema", () => {
 				createdAt: "2024-01-01",
 			},
 		};
-		const parsed = getTalentDetailResponseSchema.parse(res);
+		const parsed = getTalentDetailResponseSchema.parse(response);
 		expect(parsed.data?.idx).toBe(1);
 	});
 });

--- a/src/entities/talent/api/talent.api.ts
+++ b/src/entities/talent/api/talent.api.ts
@@ -3,8 +3,15 @@ import { okResponseSchema } from "src/shared/schema/response/response.schema";
 import type { PostTalent } from "../schema/talent.schema";
 
 /**
- * 탤런트 생성 API
- * @param data - 생성 요청 데이터
+ * @author 박상민
+ *
+ * @description 인재풀에 신규 탤런트를 등록한다.
+ * @endpoint POST /talent
+ * @auth Unnecessary
+ * @permission Unnecessary
+ *
+ * @param data - 탤런트 등록 요청 데이터 (이름, 이메일, 부서, 포트폴리오 URL)
+ * @returns 성공 응답 객체
  */
 export const PostTalentApi = (data: PostTalent) =>
 	postParsed("/talent", okResponseSchema, data);

--- a/src/features/news/query/news.query.ts
+++ b/src/features/news/query/news.query.ts
@@ -19,9 +19,9 @@ export const newsQueries = {
 		queryOptions({
 			queryKey: [...newsQueries.all, "page", page, size] as const,
 			queryFn: async ({ signal }) => {
-				const res = await getNewsApi({ page, size }, signal);
+				const response = await getNewsApi({ page, size }, signal);
 
-				const items = res.data ?? [];
+				const items = response.data ?? [];
 
 				return {
 					items,

--- a/src/features/recruit/__tests__/apply.util.test.ts
+++ b/src/features/recruit/__tests__/apply.util.test.ts
@@ -13,8 +13,8 @@ describe("currentYearMonth", () => {
 	});
 
 	it("현재 연도와 월 반환", () => {
-		const d = new Date();
-		const expected = `${d.getFullYear()}-${`${d.getMonth() + 1}`.padStart(2, "0")}`;
+		const date = new Date();
+		const expected = `${date.getFullYear()}-${`${date.getMonth() + 1}`.padStart(2, "0")}`;
 		expect(currentYearMonth()).toBe(expected);
 	});
 });

--- a/src/features/recruit/apply/form/email/api/email.api.ts
+++ b/src/features/recruit/apply/form/email/api/email.api.ts
@@ -1,12 +1,33 @@
 import BigtabletAxios from "src/shared/libs/api/axios";
 
-// 이메일 인증 요청
+/**
+ * @author 박상민
+ *
+ * @description 이메일 인증 코드를 발송한다.
+ * @endpoint POST /auth/email
+ * @auth Unnecessary
+ * @permission Unnecessary
+ *
+ * @param email - 인증 대상 이메일 주소
+ * @returns 서버 응답 데이터
+ */
 export const sendEmailApi = async (email: string) => {
 	const { data } = await BigtabletAxios.post("/auth/email", { email });
 	return data;
 };
 
-// 이메일 인증 코드 확인
+/**
+ * @author 박상민
+ *
+ * @description 이메일 인증 코드를 확인한다.
+ * @endpoint POST /auth/email/check
+ * @auth Unnecessary
+ * @permission Unnecessary
+ *
+ * @param email - 인증 대상 이메일 주소
+ * @param authCode - 사용자가 입력한 인증 코드
+ * @returns 서버 응답 데이터
+ */
 export const checkEmailApi = async (email: string, authCode: string) => {
 	const { data } = await BigtabletAxios.post("/auth/email/check", {
 		email,

--- a/src/features/recruit/apply/form/model/apply.util.ts
+++ b/src/features/recruit/apply/form/model/apply.util.ts
@@ -1,11 +1,30 @@
 import { ApplyMilitaryStatus } from "src/entities/recruit/schema/recruit.schema";
 
+/**
+ * @description 현재 연도-월을 "YYYY-MM" 형식으로 반환한다.
+ *
+ * @returns "2026-04" 등의 문자열
+ *
+ * @example
+ * currentYearMonth() // "2026-04"
+ */
 export const currentYearMonth = () => {
-	const d = new Date();
-	const m = `${d.getMonth() + 1}`.padStart(2, "0");
-	return `${d.getFullYear()}-${m}`;
+	const date = new Date();
+	const month = `${date.getMonth() + 1}`.padStart(2, "0");
+	return `${date.getFullYear()}-${month}`;
 };
 
+/**
+ * @description 전화번호를 010-XXXX-XXXX 형식으로 포맷팅한다.
+ * 010으로 시작하지 않으면 자동 교체하고 11자리로 제한한다.
+ *
+ * @param input - 사용자 입력 문자열
+ * @returns 포맷팅된 전화번호
+ *
+ * @example
+ * formatPhone010("01012345678") // "010-1234-5678"
+ * formatPhone010("010-1234")    // "010-1234"
+ */
 export const formatPhone010 = (input: string) => {
 	let digits = input.replace(/\D/g, "");
 	if (!digits.startsWith("010")) {
@@ -19,12 +38,24 @@ export const formatPhone010 = (input: string) => {
 	return digits;
 };
 
-export const mapMil = (v: string): ApplyMilitaryStatus => {
-	if (v === "DONE") return ApplyMilitaryStatus.enum.COMPLETED;
-	if (v === "PENDING") return ApplyMilitaryStatus.enum.NOT_COMPLETED;
-	if (v === "EXEMPT" || v === "")
+/**
+ * @description 병역 상태 문자열을 ApplyMilitaryStatus enum으로 매핑한다.
+ * 레거시 값("DONE", "PENDING", "EXEMPT")도 호환 처리한다.
+ *
+ * @param value - 병역 상태 문자열
+ * @returns ApplyMilitaryStatus enum 값
+ *
+ * @example
+ * mapMil("DONE")    // "COMPLETED"
+ * mapMil("PENDING") // "NOT_COMPLETED"
+ * mapMil("UNKNOWN") // "NOT_APPLICABLE"
+ */
+export const mapMil = (value: string): ApplyMilitaryStatus => {
+	if (value === "DONE") return ApplyMilitaryStatus.enum.COMPLETED;
+	if (value === "PENDING") return ApplyMilitaryStatus.enum.NOT_COMPLETED;
+	if (value === "EXEMPT" || value === "")
 		return ApplyMilitaryStatus.enum.NOT_APPLICABLE;
-	const parsed = ApplyMilitaryStatus.safeParse(v);
+	const parsed = ApplyMilitaryStatus.safeParse(value);
 	if (parsed.success) return parsed.data;
 	return ApplyMilitaryStatus.enum.NOT_APPLICABLE;
 };

--- a/src/features/recruit/apply/form/model/use-apply-submit.ts
+++ b/src/features/recruit/apply/form/model/use-apply-submit.ts
@@ -17,22 +17,22 @@ export const useApplySubmit = ({ form, jobId, emailVerified }: Params) => {
 	const mutation = useRecruitApplyMutation();
 	const router = useRouter();
 
-	const onValid = async (v: ApplyFormValues) => {
+	const onValid = async (values: ApplyFormValues) => {
 		if (!emailVerified) {
 			Toast.warning("이메일 인증을 완료해주세요.");
 			return;
 		}
-		if (v.educationLevel === "GED") {
-			v.schoolName = "";
-			v.graduationEnd = "";
-			v.department = "";
+		if (values.educationLevel === "GED") {
+			values.schoolName = "";
+			values.graduationEnd = "";
+			values.department = "";
 		}
 
 		try {
-			await mutation.mutateAsync({ ...v, jobId });
+			await mutation.mutateAsync({ ...values, jobId });
 			Toast.success("지원이 완료되었습니다.");
 			router.push("/recruit");
-		} catch (_err) {
+		} catch (_error) {
 			Toast.error("지원 중 문제가 발생했습니다.");
 		}
 	};

--- a/src/features/talent/form/model/use-talent-form.ts
+++ b/src/features/talent/form/model/use-talent-form.ts
@@ -60,11 +60,11 @@ export const useTalentForm = ({ onClose }: UseTalentFormParams) => {
 		}
 
 		try {
-			const res = await uploadFile(file);
-			const url = res.data ?? "";
+			const response = await uploadFile(file);
+			const url = response.data ?? "";
 			form.setValue("portfolioUrl", url, { shouldValidate: true });
 			form.clearErrors("portfolioUrl");
-		} catch (_err) {
+		} catch (_error) {
 			Toast.error("파일 업로드에 실패했습니다. 다시 시도해주세요.");
 			form.setValue("portfolioUrl", "", { shouldValidate: true });
 		}
@@ -72,8 +72,8 @@ export const useTalentForm = ({ onClose }: UseTalentFormParams) => {
 
 	const handleSubmit = async (values: PostTalentFormValues) => {
 		const filtered = values.etcUrl
-			.filter((v) => v.trim() !== "")
-			.map((u) => ensureHttps(u));
+			.filter((url) => url.trim() !== "")
+			.map((url) => ensureHttps(url));
 
 		const payload: PostTalent = {
 			email: values.email,

--- a/src/features/upload/model/use-upload.ts
+++ b/src/features/upload/model/use-upload.ts
@@ -18,8 +18,8 @@ export const useUpload = () => {
 			throw new Error(validation.error ?? "파일 검증에 실패했습니다.");
 		}
 
-		const res = await mutation.mutateAsync(file);
-		return res.data ?? "";
+		const response = await mutation.mutateAsync(file);
+		return response.data ?? "";
 	};
 
 	return { upload, ...mutation };

--- a/src/shared/libs/api/axios/index.ts
+++ b/src/shared/libs/api/axios/index.ts
@@ -19,7 +19,7 @@ api.interceptors.request.use(requestInterceptor, (error) =>
 );
 
 api.interceptors.response.use(
-	(res) => res,
+	(response) => response,
 	createResponseErrorInterceptor(api),
 );
 

--- a/src/shared/libs/api/gcp/__tests__/gcp.api.test.ts
+++ b/src/shared/libs/api/gcp/__tests__/gcp.api.test.ts
@@ -1,0 +1,31 @@
+import { HttpResponse, http } from "msw";
+import { server } from "src/test/msw/server";
+import { describe, expect, it } from "vitest";
+import { postGcpUploadApi } from "../gcp.api";
+
+const createMockFile = (name = "test.pdf", type = "application/pdf") =>
+	new File(["content"], name, { type });
+
+describe("postGcpUploadApi", () => {
+	it("파일 업로드가 정상 처리된다", async () => {
+		const file = createMockFile();
+		const result = await postGcpUploadApi(file);
+		expect(result).toBeDefined();
+		expect(result.data).toContain("storage.googleapis.com");
+	});
+
+	it("AbortSignal로 요청을 취소할 수 있다", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const file = createMockFile();
+		await expect(postGcpUploadApi(file, controller.signal)).rejects.toThrow();
+	});
+
+	it("서버 에러 시 예외를 throw한다", async () => {
+		server.use(
+			http.post("*/gcp", () => HttpResponse.json(null, { status: 500 })),
+		);
+		const file = createMockFile();
+		await expect(postGcpUploadApi(file)).rejects.toThrow();
+	});
+});

--- a/src/shared/libs/api/gcp/gcp.api.ts
+++ b/src/shared/libs/api/gcp/gcp.api.ts
@@ -23,7 +23,7 @@ export const postGcpUploadApi = async (
 	const formData = new FormData();
 	formData.append("multipartFile", file);
 
-	const res = await BigtabletAxios.post("/gcp", formData, {
+	const response = await BigtabletAxios.post("/gcp", formData, {
 		signal,
 		timeout: 30000,
 		withCredentials: false,
@@ -31,8 +31,8 @@ export const postGcpUploadApi = async (
 	});
 
 	return {
-		status: res.data?.status ?? 0,
-		message: res.data?.message ?? "",
-		data: res.data?.data ?? "",
+		status: response.data?.status ?? 0,
+		message: response.data?.message ?? "",
+		data: response.data?.data ?? "",
 	};
 };

--- a/src/shared/libs/api/zod/index.ts
+++ b/src/shared/libs/api/zod/index.ts
@@ -18,50 +18,98 @@ const handleNoContent = <S extends z.ZodTypeAny>(
 	return schema.parse(data);
 };
 
+/**
+ * @description GET 요청 후 Zod 스키마로 응답을 파싱한다. 204 No Content 처리 포함.
+ *
+ * @param url - 요청 URL
+ * @param schema - 응답 검증용 Zod 스키마
+ * @param config - Axios 설정 (params, signal 등)
+ * @returns 스키마로 파싱된 응답 데이터
+ * @throws Zod 파싱 실패 시 ZodError
+ */
 export const getParsed = async <S extends z.ZodTypeAny>(
 	url: string,
 	schema: S,
 	config?: AxiosConfig,
 ): Promise<z.infer<S>> => {
-	const res = await BigtabletAxios.get<unknown>(url, config);
-	return handleNoContent(res.status, res.data, schema);
+	const response = await BigtabletAxios.get<unknown>(url, config);
+	return handleNoContent(response.status, response.data, schema);
 };
 
+/**
+ * @description POST 요청 후 Zod 스키마로 응답을 파싱한다.
+ *
+ * @param url - 요청 URL
+ * @param schema - 응답 검증용 Zod 스키마
+ * @param body - 요청 본문
+ * @param config - Axios 설정
+ * @returns 스키마로 파싱된 응답 데이터
+ * @throws Zod 파싱 실패 시 ZodError
+ */
 export const postParsed = async <S extends z.ZodTypeAny>(
 	url: string,
 	schema: S,
 	body?: unknown,
 	config?: AxiosConfig,
 ): Promise<z.infer<S>> => {
-	const res = await BigtabletAxios.post<unknown>(url, body, config);
-	return schema.parse(res.data);
+	const response = await BigtabletAxios.post<unknown>(url, body, config);
+	return schema.parse(response.data);
 };
 
+/**
+ * @description PUT 요청 후 Zod 스키마로 응답을 파싱한다.
+ *
+ * @param url - 요청 URL
+ * @param schema - 응답 검증용 Zod 스키마
+ * @param body - 요청 본문
+ * @param config - Axios 설정
+ * @returns 스키마로 파싱된 응답 데이터
+ * @throws Zod 파싱 실패 시 ZodError
+ */
 export const putParsed = async <S extends z.ZodTypeAny>(
 	url: string,
 	schema: S,
 	body?: unknown,
 	config?: AxiosConfig,
 ): Promise<z.infer<S>> => {
-	const res = await BigtabletAxios.put<unknown>(url, body, config);
-	return schema.parse(res.data);
+	const response = await BigtabletAxios.put<unknown>(url, body, config);
+	return schema.parse(response.data);
 };
 
+/**
+ * @description PATCH 요청 후 Zod 스키마로 응답을 파싱한다.
+ *
+ * @param url - 요청 URL
+ * @param schema - 응답 검증용 Zod 스키마
+ * @param body - 요청 본문
+ * @param config - Axios 설정
+ * @returns 스키마로 파싱된 응답 데이터
+ * @throws Zod 파싱 실패 시 ZodError
+ */
 export const patchParsed = async <S extends z.ZodTypeAny>(
 	url: string,
 	schema: S,
 	body?: unknown,
 	config?: AxiosConfig,
 ): Promise<z.infer<S>> => {
-	const res = await BigtabletAxios.patch<unknown>(url, body, config);
-	return schema.parse(res.data);
+	const response = await BigtabletAxios.patch<unknown>(url, body, config);
+	return schema.parse(response.data);
 };
 
+/**
+ * @description DELETE 요청 후 Zod 스키마로 응답을 파싱한다.
+ *
+ * @param url - 요청 URL
+ * @param schema - 응답 검증용 Zod 스키마
+ * @param config - Axios 설정
+ * @returns 스키마로 파싱된 응답 데이터
+ * @throws Zod 파싱 실패 시 ZodError
+ */
 export const deleteParsed = async <S extends z.ZodTypeAny>(
 	url: string,
 	schema: S,
 	config?: AxiosConfig,
 ): Promise<z.infer<S>> => {
-	const res = await BigtabletAxios.delete<unknown>(url, config);
-	return schema.parse(res.data);
+	const response = await BigtabletAxios.delete<unknown>(url, config);
+	return schema.parse(response.data);
 };

--- a/src/shared/libs/env/index.ts
+++ b/src/shared/libs/env/index.ts
@@ -13,6 +13,7 @@ const envSchema = z.object({
 		.default("development"),
 });
 
+/** 검증된 환경변수 객체. 빌드/런타임 시점에 Zod 스키마로 검증된다. */
 export const env = envSchema.parse({
 	NEXT_PUBLIC_SERVER_URL: process.env.NEXT_PUBLIC_SERVER_URL,
 	NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,

--- a/src/shared/libs/ui/date/index.ts
+++ b/src/shared/libs/ui/date/index.ts
@@ -1,8 +1,19 @@
+/**
+ * @description 날짜 문자열을 상대 시간 표현으로 변환한다.
+ * "방금 전", "5분 전", "3시간 전", "2일 전" 등의 형식으로 반환.
+ *
+ * @param dateStr - 날짜 문자열 (ISO 8601)
+ * @param locale - 로케일 ("ko" 또는 "en")
+ * @returns 상대 시간 문자열 (입력이 없으면 빈 문자열)
+ *
+ * @example
+ * formatRelative("2026-04-02T10:00:00", "ko") // "3시간 전"
+ */
 export const formatRelative = (dateStr?: string, locale?: string) => {
 	if (!dateStr || !locale) return "";
-	const d = new Date(dateStr);
+	const date = new Date(dateStr);
 	const now = new Date();
-	const diffMs = d.getTime() - now.getTime();
+	const diffMs = date.getTime() - now.getTime();
 	const absSec = Math.round(Math.abs(diffMs) / 1000);
 	const rtf = new Intl.RelativeTimeFormat(
 		locale.startsWith("ko") ? "ko" : "en",

--- a/src/shared/libs/ui/text/index.ts
+++ b/src/shared/libs/ui/text/index.ts
@@ -1,3 +1,14 @@
+/**
+ * @description 텍스트가 최대 길이를 초과하면 말줄임표(…)를 추가한다.
+ *
+ * @param text - 원본 텍스트
+ * @param max - 최대 길이 (기본 120)
+ * @returns 잘린 텍스트 또는 원본 (빈 입력 시 빈 문자열)
+ *
+ * @example
+ * ellipsis("긴 텍스트...", 5) // "긴 텍스…"
+ * ellipsis(null)               // ""
+ */
 export const ellipsis = (text?: string | null, max = 120) => {
 	if (!text) return "";
 	if (text.length <= max) return text;

--- a/src/shared/ui/form/date/index.tsx
+++ b/src/shared/ui/form/date/index.tsx
@@ -10,7 +10,7 @@ import styles from "./style.module.scss";
 type Props = {
 	label?: string;
 	value?: string;
-	onChange: (v: string) => void;
+	onChange: (value: string) => void;
 	placeholder?: string;
 	disabled?: boolean;
 	error?: boolean;
@@ -19,16 +19,16 @@ type Props = {
 
 const toDate = (value?: string) => {
 	if (!value) return null;
-	const [y, m] = value.split("-").map(Number);
-	if (!y || !m) return null;
-	return new Date(y, m - 1, 1);
+	const [year, month] = value.split("-").map(Number);
+	if (!year || !month) return null;
+	return new Date(year, month - 1, 1);
 };
 
 const toValue = (date: Date | null): string => {
 	if (!date) return "";
-	const y = date.getFullYear();
-	const m = String(date.getMonth() + 1).padStart(2, "0");
-	return `${y}-${m}`;
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+	return `${year}-${month}`;
 };
 
 const MonthInput = forwardRef<
@@ -37,6 +37,16 @@ const MonthInput = forwardRef<
 >((props, ref) => <TextField {...props} ref={ref} readOnly />);
 MonthInput.displayName = "MonthInput";
 
+/**
+ * @component MonthPickerField
+ *
+ * @description
+ * 연-월 선택 날짜 피커 컴포넌트.
+ * react-datepicker 기반으로 "YYYY.MM" 형식을 사용한다.
+ *
+ * @param props.value - "YYYY-MM" 형식 문자열
+ * @param props.onChange - 선택 변경 콜백 ("YYYY-MM" 문자열 전달)
+ */
 const MonthPickerField = ({
 	label,
 	value,

--- a/src/shared/ui/form/file/index.tsx
+++ b/src/shared/ui/form/file/index.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import * as React from "react";
 import styles from "./style.module.scss";
 
+/** 파일 입력 컴포넌트 Props */
 export interface FileInputProps
 	extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange"> {
 	label?: string;
@@ -11,6 +12,16 @@ export interface FileInputProps
 	onFiles?: (file: File | null) => void;
 }
 
+/**
+ * @component FileInput
+ *
+ * @description
+ * 파일 선택 입력 컴포넌트. 이미지 파일 선택 시 미리보기를 표시한다.
+ * row/column 레이아웃을 지원한다.
+ *
+ * @param props.onFiles - 파일 선택 시 콜백 (File 또는 null)
+ * @param props.layout - 레이아웃 방향 ("row" | "column")
+ */
 export const FileInput = ({
 	label = "파일 선택",
 	layout = "column",
@@ -40,8 +51,8 @@ export const FileInput = ({
 		.filter(Boolean)
 		.join(" ");
 
-	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const file = e.currentTarget.files?.[0] ?? null;
+	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		const file = event.currentTarget.files?.[0] ?? null;
 
 		setFileName(file?.name ?? "선택된 파일 없음");
 		onFiles?.(file);

--- a/src/shared/ui/header/index.tsx
+++ b/src/shared/ui/header/index.tsx
@@ -11,6 +11,13 @@ import styles from "./style.module.scss";
 const SUPPORTED = ["ko", "en"] as const;
 type Locale = (typeof SUPPORTED)[number];
 
+/**
+ * @component Header
+ *
+ * @description
+ * 글로벌 헤더 네비게이션. 스크롤 감지 배경 변환,
+ * 모바일 햄버거 메뉴, 로케일 전환 버튼을 포함한다.
+ */
 const Header = () => {
 	const locale = useLocale() as Locale;
 	const router = useRouter();
@@ -50,7 +57,7 @@ const Header = () => {
 	}, [locale, router]);
 
 	const toggleMenu = useCallback(() => {
-		setMenuOpen((prev) => !prev);
+		setMenuOpen((previous) => !previous);
 	}, []);
 
 	const closeMenu = useCallback(() => {
@@ -108,7 +115,7 @@ const Header = () => {
 						type="button"
 						className={styles.overlay}
 						onClick={closeMenu}
-						onKeyDown={(e) => e.key === "Escape" && closeMenu()}
+						onKeyDown={(event) => event.key === "Escape" && closeMenu()}
 						aria-label="Close menu"
 					/>
 				)}

--- a/src/shared/ui/route-loading/index.tsx
+++ b/src/shared/ui/route-loading/index.tsx
@@ -39,8 +39,8 @@ const RouteLoading = () => {
 
 	// Link 클릭 감지
 	useEffect(() => {
-		const handleClick = (e: MouseEvent) => {
-			const target = e.target as HTMLElement;
+		const handleClick = (event: MouseEvent) => {
+			const target = event.target as HTMLElement;
 			const anchor = target.closest("a");
 
 			if (!anchor) return;

--- a/src/test/msw/handlers.ts
+++ b/src/test/msw/handlers.ts
@@ -1,11 +1,123 @@
-import type { RequestHandler } from "msw";
+import { type HttpHandler, HttpResponse, http } from "msw";
+
+const BASE_URL = process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:3000";
+
+/** 블로그 목록 mock 아이템 */
+const mockBlogItem = {
+	idx: 1,
+	titleKr: "테스트 블로그",
+	titleEn: "Test Blog",
+	imageUrl: "https://example.com/img.png",
+	summaryKr: "요약",
+	summaryEn: "summary",
+	contentKr: "내용",
+	contentEn: "content",
+	createdAt: "2026-01-01",
+	modifiedAt: "2026-01-02",
+	views: 10,
+};
+
+/** 뉴스 목록 mock 아이템 */
+const mockNewsItem = {
+	idx: 1,
+	titleKr: "테스트 뉴스",
+	titleEn: "Test News",
+	newsUrl: "https://example.com/news/1",
+	thumbnailImageUrl: "https://example.com/thumb.png",
+	createdAt: "2026-01-01",
+	modifiedAt: "2026-01-02",
+};
+
+/** 채용 공고 mock 아이템 */
+const mockRecruitItem = {
+	idx: 1,
+	title: "프론트엔드 개발자",
+	department: "IT",
+	location: "PANGYO",
+	recruitType: "FULL_TIME",
+	experiment: "",
+	education: "NO_REQUIREMENT",
+	companyIntroduction: "회사 소개",
+	positionIntroduction: "직무 소개",
+	mainResponsibility: "주요 업무",
+	qualification: "자격 요건",
+	preferredQualification: "우대 사항",
+	startDate: "2026-01-01",
+	endDate: null,
+	isActive: true,
+};
 
 /**
  * MSW 핸들러 목록
- * API 테스트 시 여기에 핸들러를 추가하세요.
- *
- * @example
- * import { http, HttpResponse } from "msw";
- * http.get("/api/example", () => HttpResponse.json({ data: [] }))
+ * API 테스트 시 사용되는 기본 핸들러입니다.
  */
-export const handlers: RequestHandler[] = [];
+export const handlers: HttpHandler[] = [
+	// Blog — 목록
+	http.get(`${BASE_URL}/blog/list`, () => {
+		return HttpResponse.json({
+			status: 200,
+			message: "ok",
+			data: [mockBlogItem],
+		});
+	}),
+
+	// Blog — 상세
+	http.get(`${BASE_URL}/blog`, () => {
+		return HttpResponse.json({
+			status: 200,
+			message: "ok",
+			data: mockBlogItem,
+		});
+	}),
+
+	// Blog — 조회수 증가
+	http.patch(`${BASE_URL}/blog`, () => {
+		return HttpResponse.json({ status: 200, message: "ok" });
+	}),
+
+	// News — 목록
+	http.get(`${BASE_URL}/news/list`, () => {
+		return HttpResponse.json({
+			status: 200,
+			message: "ok",
+			data: [mockNewsItem],
+		});
+	}),
+
+	// Recruit — 목록
+	http.get(`${BASE_URL}/job/list`, () => {
+		return HttpResponse.json({
+			status: 200,
+			message: "ok",
+			data: [mockRecruitItem],
+		});
+	}),
+
+	// Recruit — 상세
+	http.get(`${BASE_URL}/job`, () => {
+		return HttpResponse.json({
+			status: 200,
+			message: "ok",
+			data: mockRecruitItem,
+		});
+	}),
+
+	// Recruit — 지원
+	http.post(`${BASE_URL}/recruit`, () => {
+		return HttpResponse.json({ status: 201, message: "ok" });
+	}),
+
+	// Talent — 등록
+	http.post(`${BASE_URL}/talent`, () => {
+		return HttpResponse.json({ status: 201, message: "ok" });
+	}),
+
+	// GCP — 업로드
+	http.post(`${BASE_URL}/gcp`, () => {
+		return HttpResponse.json({
+			status: 201,
+			message: "ok",
+			data: "https://storage.googleapis.com/mock-file.pdf",
+		});
+	}),
+];

--- a/src/widgets/about/history/index.tsx
+++ b/src/widgets/about/history/index.tsx
@@ -19,6 +19,16 @@ export interface HistoryItemType {
 
 type Props = { items: HistoryItemType[] };
 
+/**
+ * @component History
+ *
+ * @description
+ * About 페이지 연혁 섹션.
+ * 연도별 탭 네비게이션과 GSAP 전환 애니메이션을 적용한다.
+ *
+ * @param props.items - 연혁 데이터 배열
+ * @see {@link buildYearGroups} 연도별 그룹핑 유틸
+ */
 const History = ({ items }: Props) => {
 	const groups: YearGroup[] = useMemo(() => buildYearGroups(items), [items]);
 	const years = useMemo(() => yearsFromGroups(groups), [groups]);
@@ -27,12 +37,14 @@ const History = ({ items }: Props) => {
 
 	useEffect(() => {
 		if (!groups.length) return;
-		setCurrentYear((prev) => prev ?? groups[0].year);
+		setCurrentYear((previous) => previous ?? groups[0].year);
 	}, [groups]);
 
 	const activeGroup = useMemo(
 		() =>
-			currentYear ? (groups.find((g) => g.year === currentYear) ?? null) : null,
+			currentYear
+				? (groups.find((group) => group.year === currentYear) ?? null)
+				: null,
 		[groups, currentYear],
 	);
 
@@ -85,14 +97,14 @@ const History = ({ items }: Props) => {
 			<div className={styles.history_grid}>
 				{/* 연도 네비게이션 (sticky) */}
 				<div className={styles.history_years}>
-					{years.map((y) => (
+					{years.map((year) => (
 						<button
-							key={y}
+							key={year}
 							type="button"
-							className={`${styles.history_year_item} ${currentYear === y ? styles.is_active : ""}`}
-							onClick={() => handleYearChange(y)}
+							className={`${styles.history_year_item} ${currentYear === year ? styles.is_active : ""}`}
+							onClick={() => handleYearChange(year)}
 						>
-							<span className={styles.history_year_text}>{y}</span>
+							<span className={styles.history_year_text}>{year}</span>
 						</button>
 					))}
 				</div>
@@ -104,14 +116,16 @@ const History = ({ items }: Props) => {
 						key={activeGroup.year}
 						className={styles.history_right}
 					>
-						{activeGroup.list.map((it) => (
-							<div key={it.id} className={styles.history_row}>
+						{activeGroup.list.map((historyItem) => (
+							<div key={historyItem.id} className={styles.history_row}>
 								<span className={styles.history_row_dot} aria-hidden />
 								<div className={styles.history_row_body}>
-									<div className={styles.history_row_title}>{it.title}</div>
-									{it.description && (
+									<div className={styles.history_row_title}>
+										{historyItem.title}
+									</div>
+									{historyItem.description && (
 										<div className={styles.history_row_desc}>
-											{it.description}
+											{historyItem.description}
 										</div>
 									)}
 								</div>

--- a/src/widgets/about/member/interview/index.tsx
+++ b/src/widgets/about/member/interview/index.tsx
@@ -7,15 +7,23 @@ interface QAItem {
 	a: string;
 }
 
+/**
+ * @component Interview
+ *
+ * @description
+ * 멤버 상세 페이지 인터뷰 Q&A 목록.
+ *
+ * @param props.items - Q&A 항목 배열
+ */
 const Interview = ({ items }: { items: QAItem[] }) => {
 	return (
 		<main className={styles.interview} aria-label="Interview">
 			<div className={styles.interview_scroll}>
 				{items.length > 0 ? (
-					items.map((it) => (
-						<article className={styles.qa} key={it.q}>
-							<h3 className={styles.qa_q}>{it.q}</h3>
-							<p className={styles.qa_a}>{it.a}</p>
+					items.map((qaItem) => (
+						<article className={styles.qa} key={qaItem.q}>
+							<h3 className={styles.qa_q}>{qaItem.q}</h3>
+							<p className={styles.qa_a}>{qaItem.a}</p>
 						</article>
 					))
 				) : (

--- a/src/widgets/about/team/index.tsx
+++ b/src/widgets/about/team/index.tsx
@@ -10,6 +10,15 @@ interface TeamProps {
 	order?: MemberKey[];
 }
 
+/**
+ * @component Team
+ *
+ * @description
+ * About 페이지 팀 소개 섹션.
+ * 멤버 카드 그리드를 표시하며, 표시 순서를 props로 제어할 수 있다.
+ *
+ * @param props.order - 멤버 표시 순서 (기본: MEMBER_DEFAULT_ORDER)
+ */
 const Team = ({ order = MEMBER_DEFAULT_ORDER }: TeamProps) => {
 	const t = useTranslations("about.team");
 

--- a/src/widgets/blog/list/index.tsx
+++ b/src/widgets/blog/list/index.tsx
@@ -16,6 +16,18 @@ interface BlogListProps {
 	hrefBuilder?: (item: BlogItem, locale: string) => string;
 }
 
+/**
+ * @component BlogListSection
+ *
+ * @description
+ * 블로그 목록 그리드 섹션. 로딩 시 스켈레톤 카드를 표시한다.
+ *
+ * @param props.items - 블로그 아이템 배열
+ * @param props.locale - 현재 로케일
+ * @param props.isLoading - 로딩 상태
+ * @param props.pageSize - 페이지 크기 (스켈레톤 수 결정)
+ * @param props.hrefBuilder - 카드 링크 생성 함수
+ */
 const BlogListSection = ({
 	items,
 	locale,
@@ -27,7 +39,7 @@ const BlogListSection = ({
 	const showSkeleton = useDeferredLoading(isLoading);
 	const t = useTranslations("blog");
 	const skeletonKeys = useMemo(
-		() => Array.from({ length: pageSize }, (_, i) => `skeleton-${i}`),
+		() => Array.from({ length: pageSize }, (_, index) => `skeleton-${index}`),
 		[pageSize],
 	);
 
@@ -36,13 +48,13 @@ const BlogListSection = ({
 			<div className={styles.blog_list_grid}>
 				{showSkeleton
 					? skeletonKeys.map((key) => <SkeletonCard key={key} />)
-					: flatItems.map((item, i) => (
+					: flatItems.map((item, index) => (
 							<BlogCard
 								key={item.idx}
 								item={item}
 								locale={locale}
 								href={hrefBuilder(item, locale)}
-								priority={i < 2}
+								priority={index < 2}
 							/>
 						))}
 			</div>

--- a/src/widgets/main/banner/index.tsx
+++ b/src/widgets/main/banner/index.tsx
@@ -9,6 +9,15 @@ import { useReducedMotion } from "src/shared/hooks/use-reduced-motion";
 import { gsap } from "src/shared/libs/gsap";
 import styles from "./style.module.scss";
 
+/**
+ * @component Banner
+ *
+ * @description
+ * 메인 페이지 상단 히어로 배너 섹션.
+ * GSAP를 사용한 텍스트 등장 애니메이션과 스크롤 유도 버튼을 포함한다.
+ *
+ * @see {@link useReducedMotion} 접근성 모션 감소 지원
+ */
 const Banner = () => {
 	const t = useTranslations("main.banner");
 	const containerRef = useRef<HTMLElement>(null);

--- a/src/widgets/main/collaborations/index.tsx
+++ b/src/widgets/main/collaborations/index.tsx
@@ -14,6 +14,15 @@ const logos = [
 const GAP = 24;
 const CARD_W = 260;
 
+/**
+ * @component Collaborations
+ *
+ * @description
+ * 메인 페이지 협력사 로고 마퀴 섹션.
+ * 뷰포트 너비에 맞춰 반복 횟수를 자동 조절한다.
+ *
+ * @param props.speed - 마퀴 스크롤 속도 (기본 40)
+ */
 const Collaborations = ({ speed = 40 }: { speed?: number }) => {
 	const t = useTranslations("main.collaboration");
 	const ref = useRef<HTMLDivElement | null>(null);
@@ -21,9 +30,12 @@ const Collaborations = ({ speed = 40 }: { speed?: number }) => {
 
 	useEffect(() => {
 		const calc = () => {
-			const w = ref.current?.offsetWidth ?? 1200;
+			const containerWidth = ref.current?.offsetWidth ?? 1200;
 			const unit = CARD_W + GAP;
-			const need = Math.max(4, Math.ceil((w * 2) / (logos.length * unit)));
+			const need = Math.max(
+				4,
+				Math.ceil((containerWidth * 2) / (logos.length * unit)),
+			);
 			setRepeat(need);
 		};
 		calc();
@@ -45,7 +57,7 @@ const Collaborations = ({ speed = 40 }: { speed?: number }) => {
 				style={{ "--gap": `${GAP}px` } as React.CSSProperties}
 			>
 				<Marquee gradient={false} speed={speed}>
-					{items.map((src, i) => (
+					{items.map((src, index) => (
 						<div className={styles.collabs_item} key={src}>
 							<div className={styles.collabs_card}>
 								<Image
@@ -54,7 +66,7 @@ const Collaborations = ({ speed = 40 }: { speed?: number }) => {
 									width={260}
 									height={60}
 									sizes="160px"
-									priority={i < 4}
+									priority={index < 4}
 									draggable={false}
 								/>
 							</div>

--- a/src/widgets/main/problem/index.tsx
+++ b/src/widgets/main/problem/index.tsx
@@ -4,6 +4,15 @@ import { useTranslations } from "next-intl";
 import { useScrollReveal } from "src/shared/hooks/use-scroll-reveal";
 import styles from "./style.module.scss";
 
+/**
+ * @component Problem
+ *
+ * @description
+ * 메인 페이지 문제 제기 섹션.
+ * 스크롤 시 fade-up 애니메이션으로 등장한다.
+ *
+ * @see {@link useScrollReveal} 스크롤 애니메이션 훅
+ */
 const Problem = () => {
 	const t = useTranslations("main.problem");
 	const sectionRef = useScrollReveal<HTMLElement>(

--- a/src/widgets/main/solution/modal/index.tsx
+++ b/src/widgets/main/solution/modal/index.tsx
@@ -8,6 +8,15 @@ import type { ModalItem, ModalProps } from "./type";
 
 const CLOSE_INTENT_DELAY = 180;
 
+/**
+ * @component Modal
+ *
+ * @description
+ * 솔루션 제품 상세 모달. 좌우 슬라이드 네비게이션과
+ * 제품 비디오 재생을 지원한다. ESC 키로 닫을 수 있다.
+ *
+ * @see {@link Portal} 모달 포탈 렌더링
+ */
 const Modal = ({
 	current,
 	ghost,
@@ -73,8 +82,8 @@ const Modal = ({
 	};
 
 	useEffect(() => {
-		const onKey = (e: KeyboardEvent) => {
-			if (e.key === "Escape" && !blockBackdropClose) close();
+		const onKey = (event: KeyboardEvent) => {
+			if (event.key === "Escape" && !blockBackdropClose) close();
 		};
 		document.addEventListener("keydown", onKey);
 		return () => document.removeEventListener("keydown", onKey);

--- a/src/widgets/main/solution/section/index.tsx
+++ b/src/widgets/main/solution/section/index.tsx
@@ -14,6 +14,16 @@ import styles from "./style.module.scss";
 type SlideState = { dir: "next" | "prev"; nextId: number } | null;
 type AnimVars = { dx: number; dy: number; sx: number; sy: number } | null;
 
+/**
+ * @component SolutionSection
+ *
+ * @description
+ * 메인 페이지 솔루션 섹션.
+ * 제품 카드 그리드와 상세 모달 열기/닫기 애니메이션을 관리한다.
+ *
+ * @see {@link Modal} 제품 상세 모달
+ * @see {@link Card} 제품 카드
+ */
 const SolutionSection = () => {
 	const t = useTranslations("main.solution");
 
@@ -36,12 +46,13 @@ const SolutionSection = () => {
 		[selected],
 	);
 
-	const idxOf = (id: number) => products.findIndex((p) => p.id === id);
+	const indexOfProduct = (id: number) =>
+		products.findIndex((product) => product.id === id);
 	const current = activeId
-		? (products.find((p) => p.id === activeId) ?? null)
+		? (products.find((product) => product.id === activeId) ?? null)
 		: null;
 	const ghost = sliding
-		? (products.find((p) => p.id === sliding.nextId) ?? null)
+		? (products.find((product) => product.id === sliding.nextId) ?? null)
 		: null;
 
 	const cancelClose = () => {
@@ -87,11 +98,11 @@ const SolutionSection = () => {
 
 	const go = (dir: "next" | "prev") => {
 		if (!activeId) return;
-		const i = idxOf(activeId);
+		const currentIndex = indexOfProduct(activeId);
 		const nextId =
 			dir === "next"
-				? products[(i + 1) % products.length].id
-				: products[(i - 1 + products.length) % products.length].id;
+				? products[(currentIndex + 1) % products.length].id
+				: products[(currentIndex - 1 + products.length) % products.length].id;
 		setBlockBackdropClose(true);
 		setSliding({ dir, nextId });
 		setTimeout(() => {
@@ -103,7 +114,8 @@ const SolutionSection = () => {
 
 	useEffect(() => {
 		if (!activeId) return;
-		const onKey = (e: KeyboardEvent) => e.key === "Escape" && closeNow();
+		const onKey = (event: KeyboardEvent) =>
+			event.key === "Escape" && closeNow();
 		window.addEventListener("keydown", onKey);
 		return () => window.removeEventListener("keydown", onKey);
 	}, [activeId, closeNow]);

--- a/src/widgets/news/list/index.tsx
+++ b/src/widgets/news/list/index.tsx
@@ -15,6 +15,17 @@ interface NewsListProps {
 	pageSize: number;
 }
 
+/**
+ * @component NewsListSection
+ *
+ * @description
+ * 뉴스 목록 그리드 섹션. 로딩 시 스켈레톤 카드를 표시한다.
+ *
+ * @param props.items - 뉴스 아이템 배열
+ * @param props.locale - 현재 로케일
+ * @param props.isLoading - 로딩 상태
+ * @param props.pageSize - 페이지 크기 (스켈레톤 수 결정)
+ */
 const NewsListSection = ({
 	items,
 	locale,
@@ -24,7 +35,7 @@ const NewsListSection = ({
 	const showSkeleton = useDeferredLoading(isLoading);
 	const t = useTranslations("news");
 	const skeletonKeys = useMemo(
-		() => Array.from({ length: pageSize }, (_, i) => `skeleton-${i}`),
+		() => Array.from({ length: pageSize }, (_, index) => `skeleton-${index}`),
 		[pageSize],
 	);
 
@@ -33,7 +44,7 @@ const NewsListSection = ({
 			return skeletonKeys.map((key) => <SkeletonCard key={key} />);
 		}
 
-		return items.map((item, i) => (
+		return items.map((item, index) => (
 			<NewsCard
 				key={item.idx}
 				title={locale === "ko" ? item.titleKr : item.titleEn}
@@ -41,7 +52,7 @@ const NewsListSection = ({
 				createdAt={item.createdAt}
 				thumbnailImageUrl={item.thumbnailImageUrl}
 				locale={locale}
-				priority={i < 3}
+				priority={index < 3}
 			/>
 		));
 	};

--- a/src/widgets/recruit/main/list/index.tsx
+++ b/src/widgets/recruit/main/list/index.tsx
@@ -18,8 +18,13 @@ interface Props {
 	filters: RecruitSearchFilters;
 }
 
-const isEmpty = (v?: string) => v === "" || v === undefined;
+const isEmpty = (value?: string) => value === "" || value === undefined;
 
+/**
+ * @component RequestCard
+ *
+ * @description 채용 공고 카드. D-Day와 태그를 표시한다.
+ */
 const RequestCard = memo(({ item }: { item: RecruitCard }) => {
 	return (
 		<a className={styles.request_item} href={`/recruit/${item.idx}`}>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
 		environment: "jsdom",
 		setupFiles: ["./vitest.setup.ts"],
 		globals: true,
+		env: {
+			NEXT_PUBLIC_SERVER_URL: "http://localhost:3000",
+		},
 		exclude: ["e2e/**", "node_modules/**"],
 		coverage: {
 			provider: "v8",
@@ -24,9 +27,7 @@ export default defineConfig({
 				"src/**/index.ts",
 				// Next.js 앱 라우터 (페이지, 레이아웃)
 				"src/app/**",
-				// API 함수 (HTTP 요청 — 통합 테스트 대상)
-				"src/**/api/*.ts",
-				"src/**/api/**/*.ts",
+				// API 함수 (MSW 테스트 추가됨 — 커버리지 포함)
 				// React 컴포넌트 및 훅 (UI 테스트 불필요)
 				"src/**/*.tsx",
 				"src/**/hooks/**",


### PR DESCRIPTION
## 제목
style/refactor-naming-jsdoc-tests

## 작업한 내용
- [x] 변수 네이밍 줄임말 제거 (45개 파일, res→response, e→event, it→entityName 등)
- [x] JSDoc 보강 (entities API, shared 유틸, widget 컴포넌트, features 훅)
- [x] MSW 핸들러 작성 (blog, news, recruit, talent, gcp 엔드포인트)
- [x] API 통합 테스트 추가 (21개 새 테스트 케이스)
- [x] vitest coverage에서 API 파일 exclusion 제거

Closes #224

## 전달할 추가 이슈
- 없음