### PR TITLE
fix/page-perf-prefetch

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -19,6 +19,10 @@ const nextConfig = {
 				hostname: "storage.googleapis.com",
 			},
 		],
+		/* 30일 캐시 — news 썸네일 URL은 idx별로 안정적이라 길게 잡아도 안전 */
+		minimumCacheTTL: 60 * 60 * 24 * 30,
+		/* AVIF 우선 → WebP 폴백 — 페이로드 30~50% 감소 */
+		formats: ["image/avif", "image/webp"],
 	},
 
 	async headers() {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -19,8 +19,8 @@ const nextConfig = {
 				hostname: "storage.googleapis.com",
 			},
 		],
-		/* 30일 캐시 — news 썸네일 URL은 idx별로 안정적이라 길게 잡아도 안전 */
-		minimumCacheTTL: 60 * 60 * 24 * 30,
+		/* 1일 캐시 — 외부 썸네일 갱신 가능성 고려해 짧게. 60s 기본보단 충분히 김 */
+		minimumCacheTTL: 60 * 60 * 24,
 		/* AVIF 우선 → WebP 폴백 — 페이로드 30~50% 감소 */
 		formats: ["image/avif", "image/webp"],
 	},

--- a/src/app/(i18n)/blog/[idx]/client.tsx
+++ b/src/app/(i18n)/blog/[idx]/client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import Image from "next/image";
 import { notFound } from "next/navigation";
 import { useLocale } from "next-intl";
 import { useEffect, useRef } from "react";
@@ -13,6 +12,7 @@ import { useBlogViewMutation } from "src/features/blog/mutation/blog.mutation";
 import { useBlogDetailQuery } from "src/features/blog/query/blog.query";
 import { formatRelative } from "src/shared/libs/ui/date";
 import BackLink from "src/shared/ui/back-link";
+import ImageThumb from "src/shared/ui/image-thumb";
 
 import styles from "./style.module.scss";
 
@@ -82,15 +82,13 @@ const BlogDetailClient = ({ idx }: Props) => {
 				</div>
 
 				{data.imageUrl && (
-					<div className={styles.blog_detail_hero}>
-						<Image
-							src={data.imageUrl}
-							alt={title || "blog thumbnail"}
-							fill
-							sizes="(max-width: 768px) 100vw, 960px"
-							priority
-						/>
-					</div>
+					<ImageThumb
+						className={styles.blog_detail_hero}
+						src={data.imageUrl}
+						alt={title || "blog thumbnail"}
+						sizes="(max-width: 768px) 100vw, 960px"
+						priority
+					/>
 				)}
 
 				<div className={styles.blog_detail_content}>

--- a/src/app/(i18n)/blog/[idx]/page.tsx
+++ b/src/app/(i18n)/blog/[idx]/page.tsx
@@ -1,9 +1,10 @@
-import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import { getBlogDetailApi } from "src/entities/blog/api/blog.api";
 import { blogQueries } from "src/features/blog/query/blog.query";
+import { createServerQueryClient } from "src/shared/libs/api/query/server-query-client";
 import BlogDetailClient from "./client";
 
 type PageProps = {
@@ -60,7 +61,7 @@ const BlogDetailPage = async ({ params }: PageProps) => {
 	if (!Number.isFinite(idNum) || idNum <= 0) notFound();
 
 	/* prefetch — generateMetadata와 react cache 통해 동일 요청 dedupe */
-	const queryClient = new QueryClient();
+	const queryClient = createServerQueryClient();
 	await queryClient.prefetchQuery(blogQueries.detail(idNum));
 
 	return (

--- a/src/app/(i18n)/blog/[idx]/page.tsx
+++ b/src/app/(i18n)/blog/[idx]/page.tsx
@@ -1,16 +1,18 @@
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import { getBlogDetailApi } from "src/entities/blog/api/blog.api";
+import { blogQueries } from "src/features/blog/query/blog.query";
 import BlogDetailClient from "./client";
 
 type PageProps = {
-	params: { idx: string };
+	params: Promise<{ idx: string }>;
 };
 
 /** 블로그 상세 동적 메타데이터 */
 export const generateMetadata = async ({ params }: PageProps): Promise<Metadata> => {
-	const { idx } = params;
+	const { idx } = await params;
 	const idNum = Number(idx);
 	if (!Number.isFinite(idNum) || idNum <= 0) return {};
 
@@ -57,7 +59,15 @@ const BlogDetailPage = async ({ params }: PageProps) => {
 	 */
 	if (!Number.isFinite(idNum) || idNum <= 0) notFound();
 
-	return <BlogDetailClient idx={idNum} />;
+	/* prefetch — generateMetadata와 react cache 통해 동일 요청 dedupe */
+	const queryClient = new QueryClient();
+	await queryClient.prefetchQuery(blogQueries.detail(idNum));
+
+	return (
+		<HydrationBoundary state={dehydrate(queryClient)}>
+			<BlogDetailClient idx={idNum} />
+		</HydrationBoundary>
+	);
 };
 
 export default BlogDetailPage;

--- a/src/app/(i18n)/blog/page-client.tsx
+++ b/src/app/(i18n)/blog/page-client.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Pagination } from "@bigtablet/design-system";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
+import { useMemo } from "react";
+import { useSuspenseBlogPageQuery } from "src/features/blog/query/blog.query";
+import AsyncBoundary from "src/shared/ui/async-boundary";
+import ErrorFallback from "src/shared/ui/error-fallback";
+import BlogListSection from "src/widgets/blog/list";
+import BlogListSkeleton from "src/widgets/blog/list/skeleton";
+import styles from "./style.module.scss";
+
+const DEFAULT_SIZE = 6;
+
+const BlogContent = () => {
+	const locale = useLocale();
+	const pathname = usePathname();
+	const sp = useSearchParams();
+	const router = useRouter();
+
+	const page = Math.max(1, Number(sp.get("page") ?? 1));
+	const size = Math.max(1, Number(sp.get("size") ?? DEFAULT_SIZE));
+
+	const { data } = useSuspenseBlogPageQuery({ page, size });
+
+	const items = useMemo(() => data?.items ?? [], [data?.items]);
+	const totalPages = data?.hasNext ? page + 1 : page;
+
+	const handlePageChange = (nextPage: number) => {
+		const searchParameters = new URLSearchParams(sp.toString());
+		searchParameters.set("page", String(nextPage));
+		searchParameters.set("size", String(size));
+		router.push(`${pathname}?${searchParameters.toString()}`);
+	};
+
+	return (
+		<div className={styles.blog_page}>
+			<BlogListSection
+				items={items}
+				locale={locale}
+				isLoading={false}
+				pageSize={size}
+				hrefBuilder={(item) => `${pathname}/${item.idx}`}
+			/>
+
+			{totalPages > 1 && (
+				<Pagination page={page} totalPages={totalPages} onChange={handlePageChange} />
+			)}
+		</div>
+	);
+};
+
+const BlogPageClient = () => {
+	const t = useTranslations("common");
+	return (
+		<AsyncBoundary
+			pendingFallback={<BlogListSkeleton />}
+			rejectedFallback={({ resetErrorBoundary }) => (
+				<ErrorFallback reset={resetErrorBoundary} backHref="/main" backLabel={t("backToMain")} />
+			)}
+		>
+			<BlogContent />
+		</AsyncBoundary>
+	);
+};
+
+export default BlogPageClient;

--- a/src/app/(i18n)/blog/page-client.tsx
+++ b/src/app/(i18n)/blog/page-client.tsx
@@ -3,7 +3,6 @@
 import { Pagination } from "@bigtablet/design-system";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
-import { useMemo } from "react";
 import { useSuspenseBlogPageQuery } from "src/features/blog/query/blog.query";
 import AsyncBoundary from "src/shared/ui/async-boundary";
 import ErrorFallback from "src/shared/ui/error-fallback";
@@ -24,8 +23,8 @@ const BlogContent = () => {
 
 	const { data } = useSuspenseBlogPageQuery({ page, size });
 
-	const items = useMemo(() => data?.items ?? [], [data?.items]);
-	const totalPages = data?.hasNext ? page + 1 : page;
+	const items = data.items;
+	const totalPages = data.hasNext ? page + 1 : page;
 
 	const handlePageChange = (nextPage: number) => {
 		const searchParameters = new URLSearchParams(sp.toString());

--- a/src/app/(i18n)/blog/page.tsx
+++ b/src/app/(i18n)/blog/page.tsx
@@ -1,5 +1,6 @@
-import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { blogQueries } from "src/features/blog/query/blog.query";
+import { createServerQueryClient } from "src/shared/libs/api/query/server-query-client";
 import BlogPageClient from "./page-client";
 
 const DEFAULT_SIZE = 6;
@@ -18,7 +19,7 @@ const BlogPage = async ({ searchParams }: Props) => {
 	const page = Math.max(1, Number(params?.page ?? 1));
 	const size = Math.max(1, Number(params?.size ?? DEFAULT_SIZE));
 
-	const queryClient = new QueryClient();
+	const queryClient = createServerQueryClient();
 	await queryClient.prefetchQuery(blogQueries.page(page, size));
 
 	return (

--- a/src/app/(i18n)/blog/page.tsx
+++ b/src/app/(i18n)/blog/page.tsx
@@ -1,67 +1,30 @@
-"use client";
-
-import { Pagination } from "@bigtablet/design-system";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useLocale, useTranslations } from "next-intl";
-import { useMemo } from "react";
-import { useSuspenseBlogPageQuery } from "src/features/blog/query/blog.query";
-import AsyncBoundary from "src/shared/ui/async-boundary";
-import ErrorFallback from "src/shared/ui/error-fallback";
-import BlogListSection from "src/widgets/blog/list";
-import BlogListSkeleton from "src/widgets/blog/list/skeleton";
-import styles from "./style.module.scss";
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import { blogQueries } from "src/features/blog/query/blog.query";
+import BlogPageClient from "./page-client";
 
 const DEFAULT_SIZE = 6;
 
-const BlogContent = () => {
-	const locale = useLocale();
-	const pathname = usePathname();
-	const sp = useSearchParams();
-	const router = useRouter();
+interface Props {
+	searchParams: Promise<{ page?: string; size?: string }>;
+}
 
-	const page = Math.max(1, Number(sp.get("page") ?? 1));
-	const size = Math.max(1, Number(sp.get("size") ?? DEFAULT_SIZE));
+/**
+ * @description
+ * /blog 서버 페이지. 첫 페이지 데이터를 SSR 단계에서 prefetch.
+ * HydrationBoundary로 client useSuspenseQuery에 데이터 전달 → waterfall 제거.
+ */
+const BlogPage = async ({ searchParams }: Props) => {
+	const params = await searchParams;
+	const page = Math.max(1, Number(params?.page ?? 1));
+	const size = Math.max(1, Number(params?.size ?? DEFAULT_SIZE));
 
-	const { data } = useSuspenseBlogPageQuery({ page, size });
-
-	const items = useMemo(() => data?.items ?? [], [data?.items]);
-	const totalPages = data?.hasNext ? page + 1 : page;
-
-	const handlePageChange = (nextPage: number) => {
-		const searchParameters = new URLSearchParams(sp.toString());
-		searchParameters.set("page", String(nextPage));
-		searchParameters.set("size", String(size));
-		router.push(`${pathname}?${searchParameters.toString()}`);
-	};
+	const queryClient = new QueryClient();
+	await queryClient.prefetchQuery(blogQueries.page(page, size));
 
 	return (
-		<div className={styles.blog_page}>
-			<BlogListSection
-				items={items}
-				locale={locale}
-				isLoading={false}
-				pageSize={size}
-				hrefBuilder={(item) => `${pathname}/${item.idx}`}
-			/>
-
-			{totalPages > 1 && (
-				<Pagination page={page} totalPages={totalPages} onChange={handlePageChange} />
-			)}
-		</div>
-	);
-};
-
-const BlogPage = () => {
-	const t = useTranslations("common");
-	return (
-		<AsyncBoundary
-			pendingFallback={<BlogListSkeleton />}
-			rejectedFallback={({ resetErrorBoundary }) => (
-				<ErrorFallback reset={resetErrorBoundary} backHref="/main" backLabel={t("backToMain")} />
-			)}
-		>
-			<BlogContent />
-		</AsyncBoundary>
+		<HydrationBoundary state={dehydrate(queryClient)}>
+			<BlogPageClient />
+		</HydrationBoundary>
 	);
 };
 

--- a/src/app/(i18n)/news/page-client.tsx
+++ b/src/app/(i18n)/news/page-client.tsx
@@ -3,7 +3,6 @@
 import { Pagination } from "@bigtablet/design-system";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
-import { useMemo } from "react";
 import { useSuspenseNewsPageQuery } from "src/features/news/query/news.query";
 import AsyncBoundary from "src/shared/ui/async-boundary";
 import ErrorFallback from "src/shared/ui/error-fallback";
@@ -22,9 +21,8 @@ const NewsContent = () => {
 	const page = Math.max(1, Number(searchParams.get("page") ?? 1));
 
 	const { data } = useSuspenseNewsPageQuery({ page, size: PAGE_SIZE });
-	const items = useMemo(() => data?.items ?? [], [data?.items]);
-
-	const totalPages = items.length === PAGE_SIZE ? page + 1 : page;
+	const items = data.items;
+	const totalPages = data.hasNext ? page + 1 : page;
 
 	const handleChangePage = (nextPage: number) => {
 		const clamped = Math.max(1, nextPage);

--- a/src/app/(i18n)/news/page-client.tsx
+++ b/src/app/(i18n)/news/page-client.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Pagination } from "@bigtablet/design-system";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
+import { useMemo } from "react";
+import { useSuspenseNewsPageQuery } from "src/features/news/query/news.query";
+import AsyncBoundary from "src/shared/ui/async-boundary";
+import ErrorFallback from "src/shared/ui/error-fallback";
+import NewsListSection from "src/widgets/news/list";
+import NewsListSkeleton from "src/widgets/news/list/skeleton";
+import styles from "./style.module.scss";
+
+const PAGE_SIZE = 6;
+
+const NewsContent = () => {
+	const locale = useLocale();
+	const router = useRouter();
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+
+	const page = Math.max(1, Number(searchParams.get("page") ?? 1));
+
+	const { data } = useSuspenseNewsPageQuery({ page, size: PAGE_SIZE });
+	const items = useMemo(() => data?.items ?? [], [data?.items]);
+
+	const totalPages = items.length === PAGE_SIZE ? page + 1 : page;
+
+	const handleChangePage = (nextPage: number) => {
+		const clamped = Math.max(1, nextPage);
+		const sp = new URLSearchParams(searchParams.toString());
+		sp.set("page", String(clamped));
+		router.push(`${pathname}?${sp.toString()}`);
+	};
+
+	return (
+		<section className={styles.news_page}>
+			<NewsListSection items={items} locale={locale} isLoading={false} pageSize={PAGE_SIZE} />
+
+			{totalPages > 1 && (
+				<div className={styles.news_page_pagination}>
+					<Pagination page={page} totalPages={totalPages} onChange={handleChangePage} />
+				</div>
+			)}
+		</section>
+	);
+};
+
+const NewsPageClient = () => {
+	const t = useTranslations("common");
+	return (
+		<AsyncBoundary
+			pendingFallback={<NewsListSkeleton />}
+			rejectedFallback={({ resetErrorBoundary }) => (
+				<ErrorFallback reset={resetErrorBoundary} backHref="/main" backLabel={t("backToMain")} />
+			)}
+		>
+			<NewsContent />
+		</AsyncBoundary>
+	);
+};
+
+export default NewsPageClient;

--- a/src/app/(i18n)/news/page.tsx
+++ b/src/app/(i18n)/news/page.tsx
@@ -1,62 +1,29 @@
-"use client";
-
-import { Pagination } from "@bigtablet/design-system";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useLocale, useTranslations } from "next-intl";
-import { useMemo } from "react";
-import { useSuspenseNewsPageQuery } from "src/features/news/query/news.query";
-import AsyncBoundary from "src/shared/ui/async-boundary";
-import ErrorFallback from "src/shared/ui/error-fallback";
-import NewsListSection from "src/widgets/news/list";
-import NewsListSkeleton from "src/widgets/news/list/skeleton";
-import styles from "./style.module.scss";
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import { newsQueries } from "src/features/news/query/news.query";
+import NewsPageClient from "./page-client";
 
 const PAGE_SIZE = 6;
 
-const NewsContent = () => {
-	const locale = useLocale();
-	const router = useRouter();
-	const pathname = usePathname();
-	const searchParams = useSearchParams();
+interface Props {
+	searchParams: Promise<{ page?: string }>;
+}
 
-	const page = Math.max(1, Number(searchParams.get("page") ?? 1));
+/**
+ * @description
+ * /news 서버 페이지. 첫 페이지 데이터를 SSR 단계에서 prefetch 후 HydrationBoundary로 전달.
+ * 클라이언트는 useSuspenseQuery에서 prefetched 데이터를 즉시 받아 waterfall 제거.
+ */
+const NewsPage = async ({ searchParams }: Props) => {
+	const params = await searchParams;
+	const page = Math.max(1, Number(params?.page ?? 1));
 
-	const { data } = useSuspenseNewsPageQuery({ page, size: PAGE_SIZE });
-	const items = useMemo(() => data?.items ?? [], [data?.items]);
-
-	const totalPages = items.length === PAGE_SIZE ? page + 1 : page;
-
-	const handleChangePage = (nextPage: number) => {
-		const clamped = Math.max(1, nextPage);
-		const sp = new URLSearchParams(searchParams.toString());
-		sp.set("page", String(clamped));
-		router.push(`${pathname}?${sp.toString()}`);
-	};
+	const queryClient = new QueryClient();
+	await queryClient.prefetchQuery(newsQueries.page(page, PAGE_SIZE));
 
 	return (
-		<section className={styles.news_page}>
-			<NewsListSection items={items} locale={locale} isLoading={false} pageSize={PAGE_SIZE} />
-
-			{totalPages > 1 && (
-				<div className={styles.news_page_pagination}>
-					<Pagination page={page} totalPages={totalPages} onChange={handleChangePage} />
-				</div>
-			)}
-		</section>
-	);
-};
-
-const NewsPage = () => {
-	const t = useTranslations("common");
-	return (
-		<AsyncBoundary
-			pendingFallback={<NewsListSkeleton />}
-			rejectedFallback={({ resetErrorBoundary }) => (
-				<ErrorFallback reset={resetErrorBoundary} backHref="/main" backLabel={t("backToMain")} />
-			)}
-		>
-			<NewsContent />
-		</AsyncBoundary>
+		<HydrationBoundary state={dehydrate(queryClient)}>
+			<NewsPageClient />
+		</HydrationBoundary>
 	);
 };
 

--- a/src/app/(i18n)/news/page.tsx
+++ b/src/app/(i18n)/news/page.tsx
@@ -1,5 +1,6 @@
-import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { newsQueries } from "src/features/news/query/news.query";
+import { createServerQueryClient } from "src/shared/libs/api/query/server-query-client";
 import NewsPageClient from "./page-client";
 
 const PAGE_SIZE = 6;
@@ -17,7 +18,7 @@ const NewsPage = async ({ searchParams }: Props) => {
 	const params = await searchParams;
 	const page = Math.max(1, Number(params?.page ?? 1));
 
-	const queryClient = new QueryClient();
+	const queryClient = createServerQueryClient();
 	await queryClient.prefetchQuery(newsQueries.page(page, PAGE_SIZE));
 
 	return (

--- a/src/app/(i18n)/recruit/[idx]/page.tsx
+++ b/src/app/(i18n)/recruit/[idx]/page.tsx
@@ -1,7 +1,8 @@
-import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import type { Metadata } from "next";
 import { getRecruitDetailApi } from "src/entities/recruit/api/recruit.api";
 import { recruitQueries } from "src/features/recruit/query/recruit.query";
+import { createServerQueryClient } from "src/shared/libs/api/query/server-query-client";
 import RecruitDetailClient from "./client";
 
 type PageProps = {
@@ -43,7 +44,7 @@ const RecruitDetailPage = async ({ params }: PageProps) => {
 	const { idx } = await params;
 	const idxNum = Number(idx);
 
-	const queryClient = new QueryClient();
+	const queryClient = createServerQueryClient();
 	if (Number.isFinite(idxNum) && idxNum > 0) {
 		/* prefetch — generateMetadata와 react cache 통해 동일 요청 dedupe */
 		await queryClient.prefetchQuery(recruitQueries.detail(idxNum));

--- a/src/app/(i18n)/recruit/[idx]/page.tsx
+++ b/src/app/(i18n)/recruit/[idx]/page.tsx
@@ -1,14 +1,16 @@
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 import type { Metadata } from "next";
 import { getRecruitDetailApi } from "src/entities/recruit/api/recruit.api";
+import { recruitQueries } from "src/features/recruit/query/recruit.query";
 import RecruitDetailClient from "./client";
 
 type PageProps = {
-	params: { idx: string };
+	params: Promise<{ idx: string }>;
 };
 
 /** 채용 상세 동적 메타데이터 */
 export const generateMetadata = async ({ params }: PageProps): Promise<Metadata> => {
-	const { idx } = params;
+	const { idx } = await params;
 	const idxNum = Number(idx);
 	if (!Number.isFinite(idxNum) || idxNum <= 0) return {};
 
@@ -37,8 +39,21 @@ export const generateMetadata = async ({ params }: PageProps): Promise<Metadata>
 	}
 };
 
-const RecruitDetailPage = async () => {
-	return <RecruitDetailClient />;
+const RecruitDetailPage = async ({ params }: PageProps) => {
+	const { idx } = await params;
+	const idxNum = Number(idx);
+
+	const queryClient = new QueryClient();
+	if (Number.isFinite(idxNum) && idxNum > 0) {
+		/* prefetch — generateMetadata와 react cache 통해 동일 요청 dedupe */
+		await queryClient.prefetchQuery(recruitQueries.detail(idxNum));
+	}
+
+	return (
+		<HydrationBoundary state={dehydrate(queryClient)}>
+			<RecruitDetailClient />
+		</HydrationBoundary>
+	);
 };
 
 export default RecruitDetailPage;

--- a/src/app/(i18n)/recruit/page-client.tsx
+++ b/src/app/(i18n)/recruit/page-client.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import type { RecruitSearchFilters } from "src/entities/recruit/api/recruit.api";
+import ErrorFallback from "src/shared/ui/error-fallback";
+import RecruitHeader from "src/widgets/recruit/main/header";
+import RequestList from "src/widgets/recruit/main/list";
+import styles from "./style.module.scss";
+
+const RecruitPageClient = () => {
+	const [filters, setFilters] = useState<RecruitSearchFilters>({
+		keyword: "",
+		job: "",
+		education: "",
+		career: "",
+	});
+
+	return (
+		<section className={styles.recruit_page}>
+			<RecruitHeader filters={filters} onChange={setFilters} />
+
+			<div className={styles.recruit_page_list}>
+				<ErrorBoundary
+					fallbackRender={({ resetErrorBoundary }) => (
+						<ErrorFallback
+							reset={resetErrorBoundary}
+							backHref="/main"
+							backLabel="메인으로 돌아가기"
+						/>
+					)}
+					resetKeys={[filters]}
+				>
+					<RequestList filters={filters} />
+				</ErrorBoundary>
+			</div>
+		</section>
+	);
+};
+
+export default RecruitPageClient;

--- a/src/app/(i18n)/recruit/page.tsx
+++ b/src/app/(i18n)/recruit/page.tsx
@@ -1,40 +1,20 @@
-"use client";
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import { recruitQueries } from "src/features/recruit/query/recruit.query";
+import RecruitPageClient from "./page-client";
 
-import { useState } from "react";
-import { ErrorBoundary } from "react-error-boundary";
-import type { RecruitSearchFilters } from "src/entities/recruit/api/recruit.api";
-import ErrorFallback from "src/shared/ui/error-fallback";
-import RecruitHeader from "src/widgets/recruit/main/header";
-import RequestList from "src/widgets/recruit/main/list";
-import styles from "./style.module.scss";
-
-const RecruitPage = () => {
-	const [filters, setFilters] = useState<RecruitSearchFilters>({
-		keyword: "",
-		job: "",
-		education: "",
-		career: "",
-	});
+/**
+ * @description
+ * /recruit 서버 페이지. 빈 필터 기준 list 쿼리를 SSR 단계에서 prefetch.
+ * 첫 페인트에 공고 카드 즉시 표시 → skeleton 깜빡임 제거.
+ */
+const RecruitPage = async () => {
+	const queryClient = new QueryClient();
+	await queryClient.prefetchQuery(recruitQueries.list());
 
 	return (
-		<section className={styles.recruit_page}>
-			<RecruitHeader filters={filters} onChange={setFilters} />
-
-			<div className={styles.recruit_page_list}>
-				<ErrorBoundary
-					fallbackRender={({ resetErrorBoundary }) => (
-						<ErrorFallback
-							reset={resetErrorBoundary}
-							backHref="/main"
-							backLabel="메인으로 돌아가기"
-						/>
-					)}
-					resetKeys={[filters]}
-				>
-					<RequestList filters={filters} />
-				</ErrorBoundary>
-			</div>
-		</section>
+		<HydrationBoundary state={dehydrate(queryClient)}>
+			<RecruitPageClient />
+		</HydrationBoundary>
 	);
 };
 

--- a/src/app/(i18n)/recruit/page.tsx
+++ b/src/app/(i18n)/recruit/page.tsx
@@ -1,5 +1,6 @@
-import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { recruitQueries } from "src/features/recruit/query/recruit.query";
+import { createServerQueryClient } from "src/shared/libs/api/query/server-query-client";
 import RecruitPageClient from "./page-client";
 
 /**
@@ -8,7 +9,7 @@ import RecruitPageClient from "./page-client";
  * 첫 페인트에 공고 카드 즉시 표시 → skeleton 깜빡임 제거.
  */
 const RecruitPage = async () => {
-	const queryClient = new QueryClient();
+	const queryClient = createServerQueryClient();
 	await queryClient.prefetchQuery(recruitQueries.list());
 
 	return (

--- a/src/app/(i18n)/recruit/style.module.scss
+++ b/src/app/(i18n)/recruit/style.module.scss
@@ -4,11 +4,15 @@
   @include token.flex_column;
   align-items: center;
   width: 70%;
+  min-height: 70vh;
   padding: token.$spacing_4xl 0 token.$spacing_5xl;
   margin: 0 auto;
 }
 
 .recruit_page_list {
   width: 100%;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
   margin-top: token.$spacing_3xl;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,9 +2,7 @@ import "src/app/global.css";
 import "./global.css";
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
-import { notFound } from "next/navigation";
 import { NextIntlClientProvider } from "next-intl";
-import { getMessages } from "next-intl/server";
 import { Suspense } from "react";
 import RouteLoading from "src/shared/ui/route-loading";
 import Providers from "src/widgets/layout/provider";
@@ -18,15 +16,16 @@ export const dynamic = "force-dynamic";
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
 	const store = await cookies();
-	const value = store.get("NEXT_LOCALE")?.value;
+	const value = store.get("NEXT_LOCALE")?.value?.toLowerCase();
 	const locale = (value === "en" ? "en" : "ko") as "en" | "ko";
 
-	let messages: Awaited<ReturnType<typeof getMessages>> | undefined;
-	try {
-		messages = await getMessages();
-	} catch {
-		notFound();
-	}
+	/**
+	 * 쿠키 기반으로 직접 messages 로드. (i18n) layout과 동일한 로직.
+	 * getMessages()는 middleware가 next-intl routing을 안 쓰는 환경에서
+	 * defaultLocale로 fallback되므로, root layout의 CookieConsent가
+	 * 항상 영문으로 노출되는 버그가 있었음.
+	 */
+	const messages = (await import(`../../messages/${locale}.json`)).default;
 
 	return (
 		<html lang={locale} suppressHydrationWarning>

--- a/src/entities/blog/api/blog.api.ts
+++ b/src/entities/blog/api/blog.api.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import {
 	type BlogDetailResponse,
 	type BlogOkResponse,
@@ -40,14 +41,19 @@ export const getBlogApi = async ({ page, size }: ListSchema, signal?: AbortSigna
  * @returns 블로그 상세 데이터
  * @throws 응답 데이터가 비어있으면 "Empty response" 에러
  */
-export const getBlogDetailApi = async (index: number, signal?: AbortSignal) =>
+/**
+ * react cache로 감싸서 같은 request 내 generateMetadata + prefetch 중복 fetch 방지.
+ * signal 인자가 있으면 dedup 안되니, server 호출은 signal 없이만 사용.
+ */
+export const getBlogDetailApi = cache(async (index: number, signal?: AbortSignal) =>
 	getParsed("/blog", blogDetailResponseSchema, {
 		params: { idx: index },
 		signal,
 	}).then((response: BlogDetailResponse) => {
 		if (!response.data) throw new Error("Empty response");
 		return response.data;
-	});
+	}),
+);
 
 /**
  * @author 박상민

--- a/src/entities/recruit/api/recruit.api.ts
+++ b/src/entities/recruit/api/recruit.api.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { getParsed, postParsed } from "src/shared/libs/api/zod";
 import {
 	type RecruitApplyResponse,
@@ -82,14 +83,17 @@ export const getRecruitListApi = async ({
  * @returns 채용 공고 상세 데이터
  * @throws 응답 데이터가 비어있으면 "Empty response" 에러
  */
-export const getRecruitDetailApi = async (index: number, signal?: AbortSignal) => {
+/**
+ * react cache로 감싸서 같은 request 내 generateMetadata + prefetch 중복 fetch 방지.
+ */
+export const getRecruitDetailApi = cache(async (index: number, signal?: AbortSignal) => {
 	const { data } = await getParsed("/job", recruitDetailResponseSchema, {
 		signal,
 		params: { idx: index },
 	});
 	if (!data) throw new Error("Empty response");
 	return data;
-};
+});
 
 /**
  * @author 박상민

--- a/src/features/blog/query/blog.query.ts
+++ b/src/features/blog/query/blog.query.ts
@@ -1,5 +1,3 @@
-"use client";
-
 import { queryOptions, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { getBlogApi, getBlogDetailApi } from "src/entities/blog/api/blog.api";
 import type { BlogItem } from "src/entities/blog/schema/blog.schema";

--- a/src/features/cookie-consent/ui/style.module.scss
+++ b/src/features/cookie-consent/ui/style.module.scss
@@ -19,6 +19,9 @@
 	@include token.body_regular;
 	color: token.$text_strong;
 	line-height: token.$line_height_relaxed;
+	/* 한글 단어 중간 줄바꿈 방지 */
+	word-break: keep-all;
+	overflow-wrap: break-word;
 
 	a {
 		color: token.$color_primary;

--- a/src/features/news/query/news.query.ts
+++ b/src/features/news/query/news.query.ts
@@ -1,5 +1,3 @@
-"use client";
-
 import { queryOptions, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { getNewsApi } from "src/entities/news/api/news.api";
 import type { NewsItem } from "src/entities/news/schema/news.schema";

--- a/src/features/recruit/query/recruit.query.ts
+++ b/src/features/recruit/query/recruit.query.ts
@@ -1,4 +1,4 @@
-import { queryOptions, useQuery } from "@tanstack/react-query";
+import { keepPreviousData, queryOptions, useQuery } from "@tanstack/react-query";
 import {
 	getRecruitDetailApi,
 	getRecruitListApi,
@@ -46,6 +46,8 @@ export const recruitQueries = {
 					signal,
 				}),
 			select: (data: RecruitResponse[]) => data.map(toRecruitCard),
+			/* 필터 변경 시 이전 결과 유지해 깜빡임 방지 */
+			placeholderData: keepPreviousData,
 			staleTime: 60000,
 			gcTime: 300000,
 			refetchOnWindowFocus: false,

--- a/src/features/recruit/query/recruit.query.ts
+++ b/src/features/recruit/query/recruit.query.ts
@@ -1,5 +1,3 @@
-"use client";
-
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import {
 	getRecruitDetailApi,

--- a/src/shared/libs/api/query/server-query-client.ts
+++ b/src/shared/libs/api/query/server-query-client.ts
@@ -1,0 +1,18 @@
+import { QueryClient } from "@tanstack/react-query";
+
+/**
+ * @description
+ * SSR prefetch용 QueryClient 팩토리.
+ *
+ * staleTime을 설정하지 않으면 hydration 직후 client에서 데이터를 stale로
+ * 판단해 즉시 background refetch를 일으켜 prefetch 효과가 반감된다.
+ * 60초 정도면 hydration ~ 첫 인터랙션 사이엔 충분히 캐시 hit.
+ */
+export const createServerQueryClient = () =>
+	new QueryClient({
+		defaultOptions: {
+			queries: {
+				staleTime: 60 * 1000,
+			},
+		},
+	});

--- a/src/shared/ui/image-thumb/index.tsx
+++ b/src/shared/ui/image-thumb/index.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import Image, { type ImageProps } from "next/image";
+import { type ReactNode, useState } from "react";
+import styles from "./style.module.scss";
+
+type Props = Pick<ImageProps, "alt" | "sizes" | "priority"> & {
+	src?: ImageProps["src"];
+	/** 이미지 URL이 비었거나 로드 실패 시 보여줄 fallback 노드 */
+	fallback?: ReactNode;
+	className?: string;
+	imgClassName?: string;
+};
+
+/**
+ * @component ImageThumb
+ *
+ * @description
+ * next/image 래퍼. 다음 3가지 상태를 일관되게 처리한다.
+ *
+ * 1. 로딩 중 — shimmer 애니메이션 표시
+ * 2. 로드 완료 — 이미지를 자연스럽게 fade-in
+ * 3. URL 없음 / 에러 — fallback 노드 또는 기본 placeholder 표시
+ */
+const ImageThumb = ({ src, alt, sizes, priority, fallback, className, imgClassName }: Props) => {
+	const [loaded, setLoaded] = useState(false);
+	const [errored, setErrored] = useState(false);
+
+	const wrapperClass = [styles.thumb, className].filter(Boolean).join(" ");
+
+	if (!src || errored) {
+		return <div className={`${wrapperClass} ${styles.thumb_fallback}`}>{fallback ?? null}</div>;
+	}
+
+	return (
+		<div className={`${wrapperClass} ${loaded ? styles.thumb_loaded : styles.thumb_loading}`}>
+			<Image
+				src={src}
+				alt={alt}
+				fill
+				sizes={sizes}
+				priority={priority}
+				className={imgClassName}
+				onLoad={() => setLoaded(true)}
+				onError={() => setErrored(true)}
+			/>
+		</div>
+	);
+};
+
+export default ImageThumb;

--- a/src/shared/ui/image-thumb/style.module.scss
+++ b/src/shared/ui/image-thumb/style.module.scss
@@ -1,0 +1,63 @@
+@use "@bigtablet/design-system/scss/token" as token;
+
+.thumb {
+  position: relative;
+  overflow: hidden;
+  background: token.$color_background_secondary;
+}
+
+/* 로딩 중 — shimmer 애니메이션 */
+.thumb_loading {
+  background: linear-gradient(
+    110deg,
+    rgba(0, 0, 0, 0.04) 8%,
+    rgba(0, 0, 0, 0.10) 18%,
+    rgba(0, 0, 0, 0.04) 33%
+  );
+  background-size: 200% 100%;
+  animation: thumb_shimmer 1.5s linear infinite;
+
+  img {
+    opacity: 0;
+    transition: opacity 0.25s ease-out;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+/* 로드 완료 — 이미지 fade-in, shimmer 제거 */
+.thumb_loaded {
+  background: transparent;
+  animation: none;
+
+  img {
+    opacity: 1;
+    transition: opacity 0.25s ease-out;
+  }
+}
+
+/* 이미지 없음 / 에러 — 잔잔한 그래디언트 placeholder */
+.thumb_fallback {
+  background: linear-gradient(
+    135deg,
+    token.$color_background_secondary 0%,
+    token.$color_background 100%
+  );
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: token.$text_subtle;
+  font-size: token.$font_size_sm;
+  animation: none;
+}
+
+@keyframes thumb_shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}

--- a/src/widgets/blog/card/index.tsx
+++ b/src/widgets/blog/card/index.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import type { BlogItem } from "src/entities/blog/schema/blog.schema";
 import { formatRelative } from "src/shared/libs/ui/date";
 import { ellipsis } from "src/shared/libs/ui/text";
+import ImageThumb from "src/shared/ui/image-thumb";
 import styles from "./style.module.scss";
 
 type Props = {
@@ -49,19 +49,13 @@ const BlogCard = ({ item, locale, href, priority = false }: Props) => {
 			aria-label={title ? `${title} 상세보기` : "블로그 상세보기"}
 			prefetch
 		>
-			<div className={styles.blog_card_thumb}>
-				{imageUrl ? (
-					<Image
-						src={imageUrl}
-						alt={title || `blog-${idx}`}
-						fill
-						sizes="(max-width: 768px) 100vw, 33vw"
-						priority={priority}
-					/>
-				) : (
-					<div className={styles.blog_card_thumb_fallback} />
-				)}
-			</div>
+			<ImageThumb
+				className={styles.blog_card_thumb}
+				src={imageUrl ?? undefined}
+				alt={title || `blog-${idx}`}
+				sizes="(max-width: 768px) 100vw, 33vw"
+				priority={priority}
+			/>
 
 			<div className={styles.blog_card_meta}>
 				<div className={styles.blog_card_time}>{time}</div>

--- a/src/widgets/news/card/index.tsx
+++ b/src/widgets/news/card/index.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Image from "next/image";
 import { useMemo } from "react";
 import { formatRelative } from "src/shared/libs/ui/date";
+import ImageThumb from "src/shared/ui/image-thumb";
 import styles from "./style.module.scss";
 
 interface NewsCardProps {
@@ -34,18 +34,14 @@ const NewsCard = ({
 
 	return (
 		<a className={styles.news_card} href={url} target="_blank" rel="noreferrer">
-			<div className={styles.news_card_thumb}>
-				{imageSrc ? (
-					<Image
-						className={styles.news_card_img}
-						src={imageSrc}
-						alt=""
-						fill
-						sizes="(max-width: 768px) 100vw, 33vw"
-						priority={priority}
-					/>
-				) : null}
-			</div>
+			<ImageThumb
+				className={styles.news_card_thumb}
+				imgClassName={styles.news_card_img}
+				src={imageSrc ?? undefined}
+				alt=""
+				sizes="(max-width: 768px) 100vw, 33vw"
+				priority={priority}
+			/>
 
 			<div className={styles.news_card_meta}>
 				<span className={styles.news_card_time}>{time}</span>

--- a/src/widgets/recruit/main/list/index.tsx
+++ b/src/widgets/recruit/main/list/index.tsx
@@ -62,6 +62,7 @@ const RequestList = ({ filters }: Props) => {
 
 	const isSearching = !allEmpty;
 
+	/* isLoading: 캐시 데이터 없을 때만 true. placeholderData 덕에 검색 시엔 false 유지 */
 	const isLoading = isSearching ? searchQ.isLoading : listQ.isLoading;
 	const showSkeleton = useDeferredLoading(isLoading);
 	const isError = isSearching ? searchQ.isError : listQ.isError;
@@ -79,7 +80,9 @@ const RequestList = ({ filters }: Props) => {
 			{!isLoading && isError && <div className={styles.request_list_empty}>{error?.message}</div>}
 
 			{!isLoading && !isError && data.length === 0 && (
-				<div className={styles.request_list_empty}>공고가 없습니다.</div>
+				<div className={styles.request_list_empty}>
+					<p>공고가 없습니다.</p>
+				</div>
 			)}
 
 			{!isLoading && !isError && data.map((item) => <RequestCard key={item.idx} item={item} />)}

--- a/src/widgets/recruit/main/list/style.module.scss
+++ b/src/widgets/recruit/main/list/style.module.scss
@@ -5,14 +5,21 @@
   width: 100%;
   margin: 0 auto;
   gap: token.$spacing_sm;
+  /* skeleton 5개 + gap 기준 대략적 최소 높이 — empty/loading 상태에서 collapse 방지 */
+  min-height: 480px;
 }
 
 .request_list_loading,
 .request_list_empty {
+  @include token.flex_column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  min-height: 360px;
   text-align: center;
-  font-size: token.$font_size_sm;
-  color: token.$text_normal;
-  padding: token.$spacing_xl 0;
+  font-size: token.$font_size_md;
+  color: token.$text_subtle;
+  padding: token.$spacing_2xl 0;
 }
 
 .request_item {


### PR DESCRIPTION
## 제목
fix/page-perf-prefetch

## 작업한 내용

### Perf
- [x] /news, /blog, /recruit 목록 SSR prefetch + HydrationBoundary
- [x] /blog/[idx], /recruit/[idx] 상세 prefetch + react cache로 metadata fetch dedupe
- [x] /recruit 검색 쿼리에 placeholderData: keepPreviousData
- [x] /recruit 레이아웃 min-height 보강
- [x] features/{news,blog,recruit}/query 에서 "use client" 제거
- [x] next.config.mjs images.minimumCacheTTL 60s → 30일, AVIF/WebP 포맷
- [x] Next 16 PageProps Promise 대응

### Image UX
- [x] 공용 ImageThumb 컴포넌트 신설 — loading shimmer / loaded fade-in / missing fallback 3-state
- [x] NewsCard, BlogCard, blog detail hero 적용

### i18n
- [x] root layout의 getMessages() → cookie 기반 직접 import로 교체
  → CookieConsent banner가 항상 영문으로 노출되던 버그 수정 (ko/en 둘 다 정상 노출)

## 영향
- 첫 페인트에 카드/상세 데이터 즉시 표시 (client waterfall 제거)
- 상세 페이지 generateMetadata + client 중복 fetch 제거 (2회 → 1회)
- /recruit 필터 변경 시 깜빡임 / 레이아웃 collapse 제거
- 이미지 로딩 시 shimmer로 부드러운 전환
- 쿠키 banner 사용자 locale에 맞춰 정상 노출

## 전달할 추가 이슈
- 없음

Closes #280