### PR TITLE
fix/cache-dedupe-and-i18n-fallback

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,8 +24,16 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 	 * getMessages()는 middleware가 next-intl routing을 안 쓰는 환경에서
 	 * defaultLocale로 fallback되므로, root layout의 CookieConsent가
 	 * 항상 영문으로 노출되는 버그가 있었음.
+	 *
+	 * import 실패 시 빈 객체로 fallback — 앱 전체가 500으로 멈추는 것보다
+	 * 일부 텍스트만 빠진 채 렌더되는 게 낫다.
 	 */
-	const messages = (await import(`../../messages/${locale}.json`)).default;
+	let messages: Record<string, unknown> = {};
+	try {
+		messages = (await import(`../../messages/${locale}.json`)).default;
+	} catch {
+		messages = {};
+	}
 
 	return (
 		<html lang={locale} suppressHydrationWarning>

--- a/src/entities/blog/api/blog.api.ts
+++ b/src/entities/blog/api/blog.api.ts
@@ -43,12 +43,11 @@ export const getBlogApi = async ({ page, size }: ListSchema, signal?: AbortSigna
  */
 /**
  * react cache로 감싸서 같은 request 내 generateMetadata + prefetch 중복 fetch 방지.
- * signal 인자가 있으면 dedup 안되니, server 호출은 signal 없이만 사용.
+ * cache 키는 인자 전체이므로 signal을 받지 않는다 — 호출부도 일관되게 signal 없이.
  */
-export const getBlogDetailApi = cache(async (index: number, signal?: AbortSignal) =>
+export const getBlogDetailApi = cache(async (index: number) =>
 	getParsed("/blog", blogDetailResponseSchema, {
 		params: { idx: index },
-		signal,
 	}).then((response: BlogDetailResponse) => {
 		if (!response.data) throw new Error("Empty response");
 		return response.data;

--- a/src/entities/recruit/api/recruit.api.ts
+++ b/src/entities/recruit/api/recruit.api.ts
@@ -85,10 +85,10 @@ export const getRecruitListApi = async ({
  */
 /**
  * react cache로 감싸서 같은 request 내 generateMetadata + prefetch 중복 fetch 방지.
+ * cache 키는 인자 전체이므로 signal을 받지 않는다 — 호출부도 일관되게 signal 없이.
  */
-export const getRecruitDetailApi = cache(async (index: number, signal?: AbortSignal) => {
+export const getRecruitDetailApi = cache(async (index: number) => {
 	const { data } = await getParsed("/job", recruitDetailResponseSchema, {
-		signal,
 		params: { idx: index },
 	});
 	if (!data) throw new Error("Empty response");

--- a/src/features/blog/query/blog.query.ts
+++ b/src/features/blog/query/blog.query.ts
@@ -30,7 +30,8 @@ export const blogQueries = {
 	detail: (idx: number) =>
 		queryOptions({
 			queryKey: [...blogQueries.all, "detail", idx] as const,
-			queryFn: ({ signal }) => getBlogDetailApi(idx, signal),
+			/* signal 미전달 — react cache 키 일관성 유지 (generateMetadata와 dedupe) */
+			queryFn: () => getBlogDetailApi(idx),
 			enabled: Number.isFinite(idx) && idx > 0,
 		}),
 };

--- a/src/features/recruit/query/recruit.query.ts
+++ b/src/features/recruit/query/recruit.query.ts
@@ -25,7 +25,8 @@ export const recruitQueries = {
 	detail: (idx: number) =>
 		queryOptions({
 			queryKey: [...recruitQueries.all, "detail", idx] as const,
-			queryFn: ({ signal }) => getRecruitDetailApi(idx, signal),
+			/* signal 미전달 — react cache 키 일관성 유지 (generateMetadata와 dedupe) */
+			queryFn: () => getRecruitDetailApi(idx),
 			select: toRecruitCard,
 			enabled: Number.isFinite(idx) && idx > 0,
 			staleTime: 60000,


### PR DESCRIPTION
## 제목
fix/cache-dedupe-and-i18n-fallback

## 작업한 내용
- [x] blog/recruit detail queryFn에서 signal 제거 (react cache 키 일관성 → metadata fetch dedupe 정상 작동)
- [x] getBlogDetailApi / getRecruitDetailApi 시그니처에서 signal 제거
- [x] root layout messages import에 try/catch 추가 (실패 시 {}로 fallback)

## 전달할 추가 이슈
- 없음

Closes #283