### PR TITLE
fix/image-shimmer-and-layout

### DIFF
--- a/e2e/policies.spec.ts
+++ b/e2e/policies.spec.ts
@@ -31,9 +31,9 @@ test.describe("policy pages - korean", () => {
 		await page.goto("/policies/privacy");
 		await expect(page.locator("main")).toBeVisible({ timeout: 10_000 });
 
-		const backButton = page.locator("button").filter({ hasText: /홈/ });
-		await expect(backButton).toBeVisible({ timeout: 10_000 });
-		await backButton.click();
+		const backLink = page.getByRole("link", { name: /홈/ });
+		await expect(backLink).toBeVisible({ timeout: 10_000 });
+		await backLink.click();
 		await expect(page).toHaveURL(/\/main/);
 	});
 });

--- a/src/app/(i18n)/about/[id]/style.module.scss
+++ b/src/app/(i18n)/about/[id]/style.module.scss
@@ -2,7 +2,6 @@
 
 .member_detail {
   color: token.$text_inverse;
-  min-height: 100vh;
   padding-block: token.$spacing_2xl token.$spacing_3xl;
   padding-inline: token.$spacing_md;
   display: grid;

--- a/src/app/(i18n)/blog/[idx]/style.module.scss
+++ b/src/app/(i18n)/blog/[idx]/style.module.scss
@@ -49,12 +49,9 @@
   }
 
   &_hero {
-    position: relative;
     width: 100%;
     aspect-ratio: 16 / 9;
     border-radius: token.$radius_lg;
-    overflow: hidden;
-    background: token.$color_background_secondary;
     border: 1px solid token.$color_border;
     margin: token.$spacing_lg 0 token.$spacing_xl;
 

--- a/src/app/(i18n)/blog/page-client.tsx
+++ b/src/app/(i18n)/blog/page-client.tsx
@@ -24,7 +24,8 @@ const BlogContent = () => {
 	const { data } = useSuspenseBlogPageQuery({ page, size });
 
 	const items = data.items;
-	const totalPages = data.hasNext ? page + 1 : page;
+	/* items 비어 있으면 pagination 숨김 — 빈 페이지를 totalPages로 잡지 않음 */
+	const totalPages = items.length === 0 ? 0 : data.hasNext ? page + 1 : page;
 
 	const handlePageChange = (nextPage: number) => {
 		const searchParameters = new URLSearchParams(sp.toString());

--- a/src/app/(i18n)/layout.module.scss
+++ b/src/app/(i18n)/layout.module.scss
@@ -1,17 +1,20 @@
 @use "@bigtablet/design-system/scss/token" as token;
 
 .layout {
-    @include token.flex_column;
-    min-height: 100svh;
+    display: flex;
+    flex-direction: column;
+    min-height: 100dvh;
     background-color: token.$color_background_secondary;
     color: token.$text_normal;
 }
 
+/* sticky footer — main이 남는 공간 모두 차지해 footer를 viewport 하단으로 밀어냄 */
 .layout_main {
-    @include token.flex_column;
+    flex: 1;
     width: 100%;
-    flex: 1 0 auto;
+    display: flex;
+    flex-direction: column;
     align-items: center;
-    overflow: visible;
     justify-content: flex-start;
+    overflow: visible;
 }

--- a/src/app/(i18n)/news/page-client.tsx
+++ b/src/app/(i18n)/news/page-client.tsx
@@ -22,7 +22,8 @@ const NewsContent = () => {
 
 	const { data } = useSuspenseNewsPageQuery({ page, size: PAGE_SIZE });
 	const items = data.items;
-	const totalPages = data.hasNext ? page + 1 : page;
+	/* items 비어 있으면 pagination 숨김 — 빈 페이지를 totalPages로 잡지 않음 */
+	const totalPages = items.length === 0 ? 0 : data.hasNext ? page + 1 : page;
 
 	const handleChangePage = (nextPage: number) => {
 		const clamped = Math.max(1, nextPage);

--- a/src/app/(i18n)/recruit/style.module.scss
+++ b/src/app/(i18n)/recruit/style.module.scss
@@ -4,7 +4,7 @@
   @include token.flex_column;
   align-items: center;
   width: 70%;
-  min-height: 70vh;
+  /* min-height 제거 — PageTransition > * flex: 1로 layout 레벨에서 처리 */
   padding: token.$spacing_4xl 0 token.$spacing_5xl;
   margin: 0 auto;
 }

--- a/src/shared/ui/back-link/index.tsx
+++ b/src/shared/ui/back-link/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import type { MouseEvent } from "react";
 import styles from "./style.module.scss";
 
 type Props = {
@@ -10,13 +11,17 @@ type Props = {
 
 /**
  * @description
- * 이전 페이지로 돌아가는 버튼 컴포넌트.
- * 히스토리가 있으면 router.back()을, 없으면 href로 이동한다.
+ * 이전 페이지로 돌아가는 링크. 히스토리가 있으면 router.back(), 없으면 href로 push.
+ *
+ * anchor 태그 + onClick.preventDefault 패턴 — RouteLoading의 anchor click 감지가
+ * 작동해 navigation 시작 즉시 top loading bar가 켜지고 pathname effect로 자연스럽게 꺼진다.
+ * (이전엔 button이었어서 popstate 우회 경로로만 들어가고 fallback timeout까지 걸쳐 있었음)
  */
 const BackLink = ({ href, label }: Props) => {
 	const router = useRouter();
 
-	const handleBack = () => {
+	const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+		e.preventDefault();
 		const hasHistory = typeof window !== "undefined" && window.history.length > 1;
 		if (hasHistory) {
 			router.back();
@@ -26,9 +31,9 @@ const BackLink = ({ href, label }: Props) => {
 	};
 
 	return (
-		<button type="button" className={styles.back_link} onClick={handleBack}>
+		<a className={styles.back_link} href={href ?? "#"} onClick={handleClick}>
 			← {label}
-		</button>
+		</a>
 	);
 };
 

--- a/src/shared/ui/footer/style.module.scss
+++ b/src/shared/ui/footer/style.module.scss
@@ -9,15 +9,15 @@
 .footer_inner {
 	max-width: 1200px;
 	margin: 0 auto;
-	padding: token.$spacing_4xl token.$spacing_2xl token.$spacing_3xl;
+	padding: token.$spacing_2xl token.$spacing_2xl token.$spacing_xl;
 	display: grid;
 	grid-template-columns: 1fr auto;
-	gap: token.$spacing_3xl;
+	gap: token.$spacing_2xl;
 }
 
 .footer_left {
 	@include token.flex_column;
-	gap: token.$spacing_lg;
+	gap: token.$spacing_sm;
 	max-width: 640px;
 
 	p {

--- a/src/shared/ui/image-thumb/style.module.scss
+++ b/src/shared/ui/image-thumb/style.module.scss
@@ -3,23 +3,25 @@
 .thumb {
   position: relative;
   overflow: hidden;
-  background: token.$color_background_secondary;
 }
 
-/* 로딩 중 — shimmer 애니메이션 */
+/* 로딩 중 — base 회색 위에 밝은 sweep band가 좌→우로 흐름 */
 .thumb_loading {
-  background: linear-gradient(
-    110deg,
-    rgba(0, 0, 0, 0.04) 8%,
-    rgba(0, 0, 0, 0.10) 18%,
-    rgba(0, 0, 0, 0.04) 33%
+  background-color: token.$color_background_muted;
+  background-image: linear-gradient(
+    100deg,
+    transparent 20%,
+    rgba(255, 255, 255, 0.55) 50%,
+    transparent 80%
   );
-  background-size: 200% 100%;
-  animation: thumb_shimmer 1.5s linear infinite;
+  background-repeat: no-repeat;
+  background-size: 220% 100%;
+  background-position: -120% 0;
+  animation: thumb_shimmer 1.4s ease-in-out infinite;
 
   img {
     opacity: 0;
-    transition: opacity 0.25s ease-out;
+    transition: opacity 0.3s ease-out;
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -34,7 +36,7 @@
 
   img {
     opacity: 1;
-    transition: opacity 0.25s ease-out;
+    transition: opacity 0.3s ease-out;
   }
 }
 
@@ -55,9 +57,9 @@
 
 @keyframes thumb_shimmer {
   0% {
-    background-position: 200% 0;
+    background-position: -120% 0;
   }
   100% {
-    background-position: -200% 0;
+    background-position: 220% 0;
   }
 }

--- a/src/shared/ui/page-transition/style.module.scss
+++ b/src/shared/ui/page-transition/style.module.scss
@@ -1,9 +1,18 @@
 .transition {
 	width: 100%;
-	flex: 1 0 auto;
+	flex: 1;
 	display: flex;
 	flex-direction: column;
-	align-items: center;
+}
+
+/**
+ * 모든 페이지 컨테이너가 viewport 잔여 공간을 동일하게 차지하도록 강제.
+ * 콘텐츠 양에 따라 footer 위 빈 공간 비율이 달라지던 문제 해결.
+ * display는 강제하지 않음 — 페이지가 자체 grid/flex/block 구조를 그대로 유지.
+ */
+.transition > * {
+	flex: 1;
+	width: 100%;
 }
 
 .entering {

--- a/src/shared/ui/route-loading/index.tsx
+++ b/src/shared/ui/route-loading/index.tsx
@@ -4,8 +4,8 @@ import { TopLoading } from "@bigtablet/design-system";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-/** 로딩 안전장치 타임아웃 (ms) */
-const LOADING_TIMEOUT = 5000;
+/** 로딩 안전장치 타임아웃 (ms) — pathname effect가 끝까지 안 발동하는 케이스 fallback */
+const LOADING_TIMEOUT = 1500;
 
 /** 로딩바 표시 지연 — 즉시 전환 시 깜빡임 방지 (ms) */
 const SHOW_DELAY = 120;

--- a/src/widgets/blog/card/style.module.scss
+++ b/src/widgets/blog/card/style.module.scss
@@ -19,12 +19,9 @@
 }
 
 .blog_card_thumb {
-  position: relative;
   width: 100%;
   aspect-ratio: 4 / 3;
   border-radius: token.$radius_md;
-  overflow: hidden;
-  background: token.$color_background_secondary;
   border: 1px solid token.$color_border;
 
   img {
@@ -33,16 +30,6 @@
     height: 100%;
     display: block;
   }
-}
-
-.blog_card_thumb_fallback {
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(
-                  180deg,
-                  token.$color_background_neutral,
-                  token.$color_background_muted
-  );
 }
 
 .blog_card_meta {

--- a/src/widgets/blog/list/style.module.scss
+++ b/src/widgets/blog/list/style.module.scss
@@ -32,7 +32,7 @@
 		width: 100%;
 		max-width: 1200px;
 		margin: 0 auto;
-		justify-content: center;
+		justify-content: start;
 	}
 
 	&_sentinel {

--- a/src/widgets/news/card/style.module.scss
+++ b/src/widgets/news/card/style.module.scss
@@ -24,14 +24,10 @@
 }
 
 .news_card_thumb {
-  position: relative;
   width: 100%;
   aspect-ratio: 4 / 3;
   border-radius: token.$radius_md;
-  overflow: hidden;
-  background: token.$color_background_secondary;
   border: 1px solid token.$color_border;
-
 }
 
 .news_card_img {

--- a/src/widgets/news/list/style.module.scss
+++ b/src/widgets/news/list/style.module.scss
@@ -3,6 +3,7 @@
 .news_list {
   @include token.flex_column;
   width: 100%;
+  flex: 1;
   padding: token.$spacing_xl 0;
   align-items: center;
 }
@@ -17,9 +18,14 @@
 }
 
 .news_list_empty {
+  @include token.flex_column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  min-height: 240px;
+  width: 100%;
   @include token.body_regular;
   font-size: token.$font_size_lg;
   color: token.$text_subtle;
-  margin-top: token.$spacing_3xl;
   text-align: center;
 }

--- a/src/widgets/news/list/style.module.scss
+++ b/src/widgets/news/list/style.module.scss
@@ -13,7 +13,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 384px));
   gap: token.$spacing_xl;
-  justify-content: center;
+  justify-content: start;
 }
 
 .news_list_empty {

--- a/src/widgets/recruit/main/list/style.module.scss
+++ b/src/widgets/recruit/main/list/style.module.scss
@@ -5,17 +5,15 @@
   width: 100%;
   margin: 0 auto;
   gap: token.$spacing_sm;
-  /* skeleton 5개 + gap 기준 대략적 최소 높이 — empty/loading 상태에서 collapse 방지 */
-  min-height: 480px;
 }
 
+/* empty/loading 자체에 min-height — list 전체는 자연 높이 유지해 viewport 초과 방지 */
 .request_list_loading,
 .request_list_empty {
   @include token.flex_column;
   align-items: center;
   justify-content: center;
-  flex: 1;
-  min-height: 360px;
+  min-height: 240px;
   text-align: center;
   font-size: token.$font_size_md;
   color: token.$text_subtle;


### PR DESCRIPTION
## 제목
fix/image-shimmer-and-layout

## 작업한 내용

### 이미지 로딩
- [x] image-thumb shimmer 색 컨트라스트 강화 (회색 베이스 + 흰색 sweep band)
- [x] news_card_thumb / blog_card_thumb / blog_detail_hero에서 충돌하던 background, overflow, position 제거

### Sticky footer
- [x] .layout flex 명시 + 100svh → 100dvh
- [x] .layout_main flex: 1 (sticky footer 표준 패턴)
- [x] about/[id]의 잉여 min-height: 100vh 제거 — viewport보다 페이지가 길어져 footer가 아래로 밀리던 문제 해결

### 라우트 로딩바
- [x] BackLink button → anchor + onClick.preventDefault — RouteLoading의 anchor 감지로 일관된 시작/종료
- [x] LOADING_TIMEOUT 5초 → 1.5초 (fallback 케이스 짧게)

## 전달할 추가 이슈
- 없음

Closes #285