### PR TITLE
fix/security-headers-csp-enforce

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,8 @@ const analyze = withBundleAnalyzer({
 const nextConfig = {
 	output: "standalone",
 	reactCompiler: true,
+	/* X-Powered-By: Next.js 헤더 제거 — 서버 기술 스택 정보 노출 방지 */
+	poweredByHeader: false,
 
 	images: {
 		remotePatterns: [
@@ -40,11 +42,20 @@ const nextConfig = {
 					},
 					{
 						key: "Strict-Transport-Security",
-						value: "max-age=63072000; includeSubDomains",
+						value: "max-age=63072000; includeSubDomains; preload",
 					},
 					{
 						key: "X-XSS-Protection",
 						value: "0",
+					},
+					/* Cross-origin isolation — observatory.mozilla.org medium */
+					{
+						key: "Cross-Origin-Opener-Policy",
+						value: "same-origin",
+					},
+					{
+						key: "Cross-Origin-Resource-Policy",
+						value: "same-site",
 					},
 				],
 			},

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,10 +9,13 @@ const DEFAULT_LOCALE = "en";
  * @description
  * CSP nonce를 생성하고 Content-Security-Policy 헤더를 설정합니다.
  */
-const buildCsp = (nonce: string) =>
-	[
+const buildCsp = (nonce: string) => {
+	/* dev에서는 React DevTools가 eval()을 사용하므로 unsafe-eval 허용. production은 strict. */
+	const isDev = process.env.NODE_ENV === "development";
+	const scriptSrc = `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ""}`;
+	return [
 		"default-src 'self'",
-		`script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+		scriptSrc,
 		"style-src 'self' 'unsafe-inline'",
 		"img-src 'self' https://storage.googleapis.com data:",
 		"font-src 'self'",
@@ -22,6 +25,7 @@ const buildCsp = (nonce: string) =>
 		"base-uri 'self'",
 		"form-action 'self'",
 	].join("; ");
+};
 
 /**
  * @description
@@ -44,7 +48,11 @@ export function middleware(request: NextRequest) {
 	requestHeaders.set("x-nonce", nonce);
 
 	const response = NextResponse.next({ request: { headers: requestHeaders } });
-	response.headers.set("Content-Security-Policy-Report-Only", buildCsp(nonce));
+	/**
+	 * 운영에서는 CSP 강제(enforce). report-only는 검사기에서 high로 평가됨.
+	 * 깨지는 inline script/style이 발견되면 nonce 부여 또는 정책 완화로 대응.
+	 */
+	response.headers.set("Content-Security-Policy", buildCsp(nonce));
 
 	// locale 쿠키 자동 설정
 	if (!request.cookies.has(LOCALE_COOKIE_KEY)) {


### PR DESCRIPTION
## 제목
fix/security-headers-csp-enforce

## 작업한 내용
- [x] CSP report-only → enforce 전환 (high)
- [x] dev 환경만 unsafe-eval 허용 (React DevTools 호환)
- [x] poweredByHeader: false (medium)
- [x] Cross-Origin-Opener-Policy: same-origin 추가 (medium)
- [x] Cross-Origin-Resource-Policy: same-site 추가 (medium)
- [x] HSTS preload directive 추가

## 전달할 추가 이슈
- style-src unsafe-inline 제거: 디자인 시스템/react-toastify nonce 적용 필요 — 추후 별도
- x-xss-protection: Cloudflare가 override 중 — Cloudflare 설정에서 처리

Closes #292