### PR TITLE
develop

### DIFF
--- a/.claude/docs/git-workflow.md
+++ b/.claude/docs/git-workflow.md
@@ -174,29 +174,43 @@ EOF
 - **제목 섹션**: Issue는 작업 설명, PR은 브랜치명
 - `## 개요`, `## 변경사항`, `## 관련 파일` 등 **다른 형식 사용 금지**
 
-## Release 양식 (필수)
+## Release 양식 (⚠️ 필수 — 자의적 변경 금지)
 
-> **⚠️ Release 본문은 반드시 아래 양식을 사용해야 합니다. 자의적으로 섹션을 변경하거나 추가하지 마세요.**
+> **Release 본문은 반드시 아래 양식 그대로 사용. 섹션 추가/삭제/이름 변경 모두 금지.**
 
 - **태그 형식**: `x.x.x` (v 접두사 없음, 예: `1.8.6`)
 - **제목**: 태그와 동일 (예: `1.8.6`)
+- **타겟 브랜치**: `main` (develop → main 머지 후 main 기준 생성)
+
+### 본문 템플릿
 
 ```markdown
 ## Official Website Web of Bigtablet, Inc.
+
 #### Key Updates
-- 변경사항 1
-- 변경사항 2
+- <conventional commit-style line, 영문 소문자>
+- <conventional commit-style line, 영문 소문자>
 ```
 
-- 각 변경사항은 영문 소문자로 작성
-- develop → main 머지 후 main 브랜치를 타겟으로 생성
+### 규칙
+
+- 첫 줄 `## Official Website Web of Bigtablet, Inc.` — 텍스트 그대로 (변경 금지)
+- 두 번째 `#### Key Updates` — 텍스트 그대로 (변경 금지)
+- bullet 한 줄 = 하나의 변경 사항. **영문 소문자 + conventional prefix** (`fix:`, `feat:`, `chore:`, `delete:`, `style:`, `refactor:` 등)
+- ❌ `## Features` / `## Bug Fixes` / `## Performance` / `## Security` 등 **카테고리 섹션 절대 추가 금지**
+- ❌ 한글 본문 금지 — 한글 commit 메시지였어도 release 본문은 영문 소문자로 변환
+- ❌ bullet을 빈 줄로 그룹화 금지 — 모든 bullet 연속
+
+### 생성 예시
 
 ```bash
 gh release create 1.8.6 --target main --title "1.8.6" --notes "$(cat <<'EOF'
 ## Official Website Web of Bigtablet, Inc.
+
 #### Key Updates
-- add new feature description
-- fix bug description
+- feat: add new feature description
+- fix: bug description
+- chore: bump dependency from x to y
 EOF
 )"
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,39 @@ src/
   ```
 - **PR 제목 = 브랜치명** (설명문 아님, 예: `fix/detail-page-pagination`)
 
-### Release Tag 규칙 (⚠️ 필수 준수)
+### Release 규칙 (⚠️ 필수 준수)
 
 - **태그 형식: `X.Y.Z`** — `v` 접두사 절대 사용 금지 (예: `1.9.0` ✅, `v1.9.0` ❌)
+- **제목**: 태그와 동일 (예: `1.9.0`)
+- **타겟 브랜치**: `main` (develop → main 머지 후 main 기준 생성)
+
+#### Release 본문 양식 (자의적 변경 금지)
+
+```markdown
+## Official Website Web of Bigtablet, Inc.
+
+#### Key Updates
+- <conventional commit-style line, 영문 소문자>
+- <conventional commit-style line, 영문 소문자>
+```
+
+- 첫 줄: `## Official Website Web of Bigtablet, Inc.` (절대 변경 금지)
+- 두 번째: `#### Key Updates` (절대 변경 금지)
+- 본문은 **영문 소문자 conventional commit 스타일** (`fix:`, `feat:`, `chore:`, `delete:` 등) 한 줄씩
+- ❌ `## Features` / `## Bug Fixes` / `## Performance` 등 카테고리 섹션 추가 금지
+- ❌ 한글 본문 금지 — 모두 영문 소문자
+- ❌ 빈 줄로 그룹 분리 금지
+
+생성 예시:
+
+```bash
+gh release create 1.9.0 --target main --title "1.9.0" --notes "$(cat <<'EOF'
+## Official Website Web of Bigtablet, Inc.
+
+#### Key Updates
+- feat: add new feature description
+- fix: bug description
+- chore: bump dependency from x to y
+EOF
+)"
+```

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,8 @@ const analyze = withBundleAnalyzer({
 const nextConfig = {
 	output: "standalone",
 	reactCompiler: true,
+	/* X-Powered-By: Next.js 헤더 제거 — 서버 기술 스택 정보 노출 방지 */
+	poweredByHeader: false,
 
 	images: {
 		remotePatterns: [
@@ -40,11 +42,20 @@ const nextConfig = {
 					},
 					{
 						key: "Strict-Transport-Security",
-						value: "max-age=63072000; includeSubDomains",
+						value: "max-age=63072000; includeSubDomains; preload",
 					},
 					{
 						key: "X-XSS-Protection",
 						value: "0",
+					},
+					/* Cross-origin isolation — observatory.mozilla.org medium */
+					{
+						key: "Cross-Origin-Opener-Policy",
+						value: "same-origin",
+					},
+					{
+						key: "Cross-Origin-Resource-Policy",
+						value: "same-site",
 					},
 				],
 			},

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,10 +9,13 @@ const DEFAULT_LOCALE = "en";
  * @description
  * CSP nonce를 생성하고 Content-Security-Policy 헤더를 설정합니다.
  */
-const buildCsp = (nonce: string) =>
-	[
+const buildCsp = (nonce: string) => {
+	/* dev에서는 React DevTools가 eval()을 사용하므로 unsafe-eval 허용. production은 strict. */
+	const isDev = process.env.NODE_ENV === "development";
+	const scriptSrc = `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ""}`;
+	return [
 		"default-src 'self'",
-		`script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+		scriptSrc,
 		"style-src 'self' 'unsafe-inline'",
 		"img-src 'self' https://storage.googleapis.com data:",
 		"font-src 'self'",
@@ -22,6 +25,7 @@ const buildCsp = (nonce: string) =>
 		"base-uri 'self'",
 		"form-action 'self'",
 	].join("; ");
+};
 
 /**
  * @description
@@ -44,7 +48,11 @@ export function middleware(request: NextRequest) {
 	requestHeaders.set("x-nonce", nonce);
 
 	const response = NextResponse.next({ request: { headers: requestHeaders } });
-	response.headers.set("Content-Security-Policy-Report-Only", buildCsp(nonce));
+	/**
+	 * 운영에서는 CSP 강제(enforce). report-only는 검사기에서 high로 평가됨.
+	 * 깨지는 inline script/style이 발견되면 nonce 부여 또는 정책 완화로 대응.
+	 */
+	response.headers.set("Content-Security-Policy", buildCsp(nonce));
 
 	// locale 쿠키 자동 설정
 	if (!request.cookies.has(LOCALE_COOKIE_KEY)) {

--- a/src/shared/ui/page-transition/style.module.scss
+++ b/src/shared/ui/page-transition/style.module.scss
@@ -6,13 +6,12 @@
 }
 
 /**
- * 모든 페이지 컨테이너가 viewport 잔여 공간을 동일하게 차지하도록 강제.
- * 콘텐츠 양에 따라 footer 위 빈 공간 비율이 달라지던 문제 해결.
- * display는 강제하지 않음 — 페이지가 자체 grid/flex/block 구조를 그대로 유지.
+ * 모든 페이지 컨테이너가 viewport 잔여 공간을 동일하게 차지하도록 flex grow만 부여.
+ * width는 강제하지 않음 — 페이지가 자체 width(예: recruit 70%)를 그대로 유지.
+ * align-items: stretch(기본) + width 미지정 페이지는 자연스럽게 100% 차지.
  */
 .transition > * {
 	flex: 1;
-	width: 100%;
 }
 
 .entering {


### PR DESCRIPTION
## 제목
develop

## 작업한 내용
- [x] docs: release 본문 양식 강제 — CLAUDE.md / .claude/docs/git-workflow.md 보강 (#289)
- [x] fix: page-transition `> *`에서 width: 100% 제거 — recruit_page width: 70% 복원 (#291)
- [x] fix: security headers 강화 — CSP enforce, COOP/CORP, poweredByHeader off, HSTS preload (#293)

## 전달할 추가 이슈
- 없음