### PR TITLE
config/next-bundle-analyzer-fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
 		"e2e": "playwright test",
 		"e2e:start": "cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public && node .next/standalone/server.js",
 		"e2e:ui": "playwright test --ui",
-		"analyze": "ANALYZE=true next build --turbopack",
+		"analyze": "ANALYZE=true next build",
 		"prepare": "husky"
 	},
 	"dependencies": {
 		"@bigtablet/design-system": "1.22.0",
 		"@gsap/react": "^2.1.2",
 		"@hookform/resolvers": "^5.2.2",
+		"@next/bundle-analyzer": "^16.2.5",
 		"@opentelemetry/api": "^1.9.1",
 		"@sentry/nextjs": "^10.51.0",
 		"@tanstack/react-query": "^5.99.0",
@@ -52,7 +53,6 @@
 		"@biomejs/biome": "^2.4.12",
 		"@commitlint/cli": "^20.5.3",
 		"@commitlint/core": "^20.5.0",
-		"@next/bundle-analyzer": "^16.2.5",
 		"@playwright/test": "^1.59.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.1(react@19.2.5))
+      '@next/bundle-analyzer':
+        specifier: ^16.2.5
+        version: 16.2.5
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -102,9 +105,6 @@ importers:
       '@commitlint/core':
         specifier: ^20.5.0
         version: 20.5.0(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
-      '@next/bundle-analyzer':
-        specifier: ^16.2.5
-        version: 16.2.5
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1


### PR DESCRIPTION
## 제목
config/next-bundle-analyzer-fix

## 작업한 내용
- [x] @next/bundle-analyzer를 devDependencies → dependencies로 이동 (next.config.mjs top-level import, standalone/--prod 환경 크래시 방지)
- [x] analyze script에서 --turbopack flag 제거 (bundle-analyzer는 webpack 빌드만 지원)

## 전달할 추가 이슈
- 없음