### PR TITLE
fix/hydration-mismatch-relative-date

### DIFF
--- a/src/app/(i18n)/blog/[idx]/client.tsx
+++ b/src/app/(i18n)/blog/[idx]/client.tsx
@@ -10,7 +10,7 @@ const ReactMarkdown = dynamic(() => import("react-markdown"), { ssr: false });
 
 import { useBlogViewMutation } from "src/features/blog/mutation/blog.mutation";
 import { useBlogDetailQuery } from "src/features/blog/query/blog.query";
-import { formatRelative } from "src/shared/libs/ui/date";
+import { formatDate } from "src/shared/libs/ui/date";
 import BackLink from "src/shared/ui/back-link";
 import ImageThumb from "src/shared/ui/image-thumb";
 
@@ -64,7 +64,7 @@ const BlogDetailClient = ({ idx }: Props) => {
 
 	const title = locale.startsWith("ko") ? data.titleKr : data.titleEn;
 	const content = locale.startsWith("ko") ? data.contentKr : data.contentEn;
-	const time = formatRelative(data.createdAt, locale);
+	const time = formatDate(data.createdAt, locale);
 
 	return (
 		<section className={styles.blog_detail}>

--- a/src/shared/libs/ui/date/index.ts
+++ b/src/shared/libs/ui/date/index.ts
@@ -1,28 +1,27 @@
 /**
- * @description 날짜 문자열을 상대 시간 표현으로 변환한다.
- * "방금 전", "5분 전", "3시간 전", "2일 전" 등의 형식으로 반환.
+ * @description ISO 날짜 문자열을 로케일별 실제 날짜 표기로 변환한다.
  *
- * @param dateStr - 날짜 문자열 (ISO 8601)
+ * 예전엔 "X분 전" 같은 상대 시간을 반환했지만, server 렌더와 client 렌더
+ * 사이에 흐른 시간 차로 인해 텍스트가 달라져 React hydration mismatch
+ * (#418)를 일으켰다. 이로 인해 React가 SSR HTML을 버리고 client에서 다시
+ * 렌더링하면서 초기 페인트가 느려졌다. 절대 날짜는 입력에만 의존하므로
+ * server/client 결과가 일치한다.
+ *
+ * @param dateStr - ISO 8601 날짜 문자열
  * @param locale - 로케일 ("ko" 또는 "en")
- * @returns 상대 시간 문자열 (입력이 없으면 빈 문자열)
+ * @returns 로케일에 맞는 날짜 문자열 (입력 누락 시 빈 문자열)
  *
  * @example
- * formatRelative("2026-04-02T10:00:00", "ko") // "3시간 전"
+ * formatRelative("2026-04-02T10:00:00", "ko") // "2026. 4. 2."
+ * formatRelative("2026-04-02T10:00:00", "en") // "Apr 2, 2026"
  */
 export const formatRelative = (dateStr?: string, locale?: string) => {
 	if (!dateStr || !locale) return "";
 	const date = new Date(dateStr);
-	const now = new Date();
-	const diffMs = date.getTime() - now.getTime();
-	const absSec = Math.round(Math.abs(diffMs) / 1000);
-	const rtf = new Intl.RelativeTimeFormat(locale.startsWith("ko") ? "ko" : "en", {
-		numeric: "auto",
-	});
-
-	if (absSec < 60) return rtf.format(Math.round(diffMs / 1000), "second");
-	const absMin = Math.round(absSec / 60);
-	if (absMin < 60) return rtf.format(Math.round(diffMs / (60 * 1000)), "minute");
-	const absHr = Math.round(absMin / 60);
-	if (absHr < 24) return rtf.format(Math.round(diffMs / (60 * 60 * 1000)), "hour");
-	return rtf.format(Math.round(diffMs / (24 * 60 * 60 * 1000)), "day");
+	if (Number.isNaN(date.getTime())) return "";
+	return new Intl.DateTimeFormat(locale.startsWith("ko") ? "ko" : "en", {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	}).format(date);
 };

--- a/src/shared/libs/ui/date/index.ts
+++ b/src/shared/libs/ui/date/index.ts
@@ -3,19 +3,21 @@
  *
  * 예전엔 "X분 전" 같은 상대 시간을 반환했지만, server 렌더와 client 렌더
  * 사이에 흐른 시간 차로 인해 텍스트가 달라져 React hydration mismatch
- * (#418)를 일으켰다. 이로 인해 React가 SSR HTML을 버리고 client에서 다시
- * 렌더링하면서 초기 페인트가 느려졌다. 절대 날짜는 입력에만 의존하므로
- * server/client 결과가 일치한다.
+ * (#418)를 일으켰다. 절대 날짜는 입력에만 의존하므로 server/client 결과가
+ * 일치한다.
+ *
+ * timeZone: "Asia/Seoul"을 명시해 server(UTC) vs client(KST)에서 같은
+ * 입력에 다른 날짜가 나오는 일을 막는다. 미명시 시 시스템 시간대 사용.
  *
  * @param dateStr - ISO 8601 날짜 문자열
  * @param locale - 로케일 ("ko" 또는 "en")
  * @returns 로케일에 맞는 날짜 문자열 (입력 누락 시 빈 문자열)
  *
  * @example
- * formatRelative("2026-04-02T10:00:00", "ko") // "2026. 4. 2."
- * formatRelative("2026-04-02T10:00:00", "en") // "Apr 2, 2026"
+ * formatDate("2026-04-02T10:00:00Z", "ko") // "2026. 4. 2."
+ * formatDate("2026-04-02T10:00:00Z", "en") // "Apr 2, 2026"
  */
-export const formatRelative = (dateStr?: string, locale?: string) => {
+export const formatDate = (dateStr?: string, locale?: string) => {
 	if (!dateStr || !locale) return "";
 	const date = new Date(dateStr);
 	if (Number.isNaN(date.getTime())) return "";
@@ -23,5 +25,6 @@ export const formatRelative = (dateStr?: string, locale?: string) => {
 		year: "numeric",
 		month: "short",
 		day: "numeric",
+		timeZone: "Asia/Seoul",
 	}).format(date);
 };

--- a/src/shared/test/date.test.ts
+++ b/src/shared/test/date.test.ts
@@ -1,33 +1,33 @@
-import { formatRelative } from "src/shared/libs/ui/date";
+import { formatDate } from "src/shared/libs/ui/date";
 import { describe, expect, it } from "vitest";
 
-describe("formatRelative", () => {
+describe("formatDate", () => {
 	it("인자 없으면 빈 문자열 반환", () => {
-		expect(formatRelative(undefined, "ko")).toBe("");
-		expect(formatRelative("2026-03-11", undefined)).toBe("");
+		expect(formatDate(undefined, "ko")).toBe("");
+		expect(formatDate("2026-03-11", undefined)).toBe("");
 	});
 
 	it("유효하지 않은 날짜는 빈 문자열 반환", () => {
-		expect(formatRelative("not-a-date", "ko")).toBe("");
+		expect(formatDate("not-a-date", "ko")).toBe("");
 	});
 
 	it("ko 로케일 — 연도/월/일 포함", () => {
-		const result = formatRelative("2026-03-11T12:00:00Z", "ko");
+		const result = formatDate("2026-03-11T12:00:00Z", "ko");
 		expect(result).toContain("2026");
 		expect(result).toMatch(/3월|03/);
 		expect(result).toContain("11");
 	});
 
 	it("en 로케일 — 영문 월 표기 포함", () => {
-		const result = formatRelative("2026-03-11T12:00:00Z", "en");
+		const result = formatDate("2026-03-11T12:00:00Z", "en");
 		expect(result).toContain("Mar");
 		expect(result).toContain("2026");
 	});
 
 	it("동일 입력은 동일 출력 (server/client hydration 일관성)", () => {
 		const dateStr = "2026-04-02T10:00:00Z";
-		const a = formatRelative(dateStr, "ko");
-		const b = formatRelative(dateStr, "ko");
+		const a = formatDate(dateStr, "ko");
+		const b = formatDate(dateStr, "ko");
 		expect(a).toBe(b);
 	});
 });

--- a/src/shared/test/date.test.ts
+++ b/src/shared/test/date.test.ts
@@ -1,48 +1,33 @@
 import { formatRelative } from "src/shared/libs/ui/date";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 describe("formatRelative", () => {
-	beforeEach(() => {
-		vi.useFakeTimers();
-		vi.setSystemTime(new Date("2026-03-11T12:00:00Z"));
-	});
-
-	afterEach(() => {
-		vi.useRealTimers();
-	});
-
 	it("인자 없으면 빈 문자열 반환", () => {
 		expect(formatRelative(undefined, "ko")).toBe("");
 		expect(formatRelative("2026-03-11", undefined)).toBe("");
 	});
 
-	it("30초 전 — 초 단위 (ko)", () => {
-		const dateStr = new Date(Date.now() - 30_000).toISOString();
-		const result = formatRelative(dateStr, "ko");
-		expect(result).toContain("초");
+	it("유효하지 않은 날짜는 빈 문자열 반환", () => {
+		expect(formatRelative("not-a-date", "ko")).toBe("");
 	});
 
-	it("5분 전 — 분 단위 (ko)", () => {
-		const dateStr = new Date(Date.now() - 5 * 60_000).toISOString();
-		const result = formatRelative(dateStr, "ko");
-		expect(result).toContain("분");
+	it("ko 로케일 — 연도/월/일 포함", () => {
+		const result = formatRelative("2026-03-11T12:00:00Z", "ko");
+		expect(result).toContain("2026");
+		expect(result).toMatch(/3월|03/);
+		expect(result).toContain("11");
 	});
 
-	it("3시간 전 — 시간 단위 (ko)", () => {
-		const dateStr = new Date(Date.now() - 3 * 3600_000).toISOString();
-		const result = formatRelative(dateStr, "ko");
-		expect(result).toContain("시간");
+	it("en 로케일 — 영문 월 표기 포함", () => {
+		const result = formatRelative("2026-03-11T12:00:00Z", "en");
+		expect(result).toContain("Mar");
+		expect(result).toContain("2026");
 	});
 
-	it("5일 전 — 일 단위 (ko)", () => {
-		const dateStr = new Date(Date.now() - 5 * 86400_000).toISOString();
-		const result = formatRelative(dateStr, "ko");
-		expect(result).toContain("일");
-	});
-
-	it("en 로케일 지원", () => {
-		const dateStr = new Date(Date.now() - 2 * 86400_000).toISOString();
-		const result = formatRelative(dateStr, "en");
-		expect(result).toContain("day");
+	it("동일 입력은 동일 출력 (server/client hydration 일관성)", () => {
+		const dateStr = "2026-04-02T10:00:00Z";
+		const a = formatRelative(dateStr, "ko");
+		const b = formatRelative(dateStr, "ko");
+		expect(a).toBe(b);
 	});
 });

--- a/src/widgets/blog/card/index.tsx
+++ b/src/widgets/blog/card/index.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import type { BlogItem } from "src/entities/blog/schema/blog.schema";
-import { formatRelative } from "src/shared/libs/ui/date";
+import { formatDate } from "src/shared/libs/ui/date";
 import { ellipsis } from "src/shared/libs/ui/text";
 import ImageThumb from "src/shared/ui/image-thumb";
 import styles from "./style.module.scss";
@@ -40,7 +40,7 @@ const BlogCard = ({ item, locale, href, priority = false }: Props) => {
 	const title = (isKo ? titleKr : titleEn) ?? "";
 	const content = (isKo ? contentKr : contentEn) ?? "";
 	const plainContent = stripMarkdown(content);
-	const time = formatRelative(createdAt, locale);
+	const time = formatDate(createdAt, locale);
 
 	return (
 		<Link

--- a/src/widgets/news/card/index.tsx
+++ b/src/widgets/news/card/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { formatRelative } from "src/shared/libs/ui/date";
+import { formatDate } from "src/shared/libs/ui/date";
 import ImageThumb from "src/shared/ui/image-thumb";
 import styles from "./style.module.scss";
 
@@ -24,7 +24,7 @@ const NewsCard = ({
 	source,
 	priority = false,
 }: NewsCardProps) => {
-	const time = useMemo(() => formatRelative(createdAt, locale), [createdAt, locale]);
+	const time = useMemo(() => formatDate(createdAt, locale), [createdAt, locale]);
 
 	const imageSrc = useMemo(() => {
 		const trimmed = thumbnailImageUrl?.trim();


### PR DESCRIPTION
## 제목
fix/hydration-mismatch-relative-date

## 작업한 내용
- [x] formatRelative를 상대 시간 (Date.now() 의존) → 절대 날짜 (Intl.DateTimeFormat)로 변경
- [x] React #418 hydration mismatch 에러 해결 → 초기 페인트/라우팅 속도 개선
- [x] 테스트 재작성 (server/client 일관성 검증 포함)

## 영향
- News/Blog 카드, Blog detail 페이지에서 "X분 전" → 실제 날짜 표기 ("2026. 4. 2." / "Apr 2, 2026")
- React가 더 이상 SSR HTML을 폐기하지 않음 → 초기 라우팅 속도 향상

## 전달할 추가 이슈
- Cloudflare Email Obfuscation 차단: Cloudflare 대시보드 → Scrape Shield → Email Address Obfuscation OFF (코드 외부 처리)

Closes #304