### PR TITLE
fix/server-components-and-i18n-coverage

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3,7 +3,28 @@
 		"backToHome": "Home",
 		"backToMain": "Back to Main",
 		"backToList": "Back to List",
-		"backToTeam": "Back to Team"
+		"backToListGeneric": "Back to List",
+		"backToTeam": "Back to Team",
+		"backToBlog": "Blog List",
+		"backToBlogList": "Back to Blog List",
+		"backToRecruit": "Recruit List",
+		"backToRecruitList": "Back to Recruit List",
+		"backToAboutTeam": "Back to Team Overview"
+	},
+	"error": {
+		"title": "Something went wrong",
+		"description": "An error occurred while loading this page.\nPlease try again in a moment.",
+		"retry": "Try again",
+		"globalDescription": "A temporary error occurred.\nPlease try again in a moment.",
+		"retryCooldown": "Retry in {seconds}s",
+		"retryDisabled": "Retry unavailable",
+		"retryProgress": "Retry {current}/{max}",
+		"retryExceeded": "Retry limit exceeded.\nPlease contact the administrator if the issue persists.",
+		"goHome": "Go to home",
+		"goBack": "Previous page",
+		"notFoundCode": "404",
+		"notFoundTitle": "Page not found",
+		"notFoundDescription": "The page you requested does not exist\nor has been moved."
 	},
 	"footer": {
 		"brand": "Bigtablet, Inc.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -26,6 +26,19 @@
 		"notFoundTitle": "Page not found",
 		"notFoundDescription": "The page you requested does not exist\nor has been moved."
 	},
+	"recruit": {
+		"detail": {
+			"loading": "Loading…",
+			"loadFailed": "Failed to load.",
+			"section": {
+				"company": "About the Organization",
+				"position": "About the Position",
+				"responsibility": "Key Responsibilities",
+				"qualification": "Qualifications",
+				"preferredQualification": "Preferred Qualifications"
+			}
+		}
+	},
 	"footer": {
 		"brand": "Bigtablet, Inc.",
 		"address": "440 N. Wolfe Rd, Sunnyvale, CA 94085",
@@ -384,7 +397,10 @@
 	},
 	"blog": {
 		"title": "Blog",
-		"empty": "No blog posts yet."
+		"empty": "No blog posts yet.",
+		"detail": {
+			"views": "views"
+		}
 	},
 	"cookie": {
 		"message": "This website uses cookies for a better experience.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -26,6 +26,19 @@
 		"notFoundTitle": "페이지를 찾을 수 없습니다",
 		"notFoundDescription": "요청하신 페이지가 존재하지 않거나\n잘못된 접근입니다."
 	},
+	"recruit": {
+		"detail": {
+			"loading": "불러오는 중…",
+			"loadFailed": "불러오지 못했습니다.",
+			"section": {
+				"company": "조직 소개",
+				"position": "포지션 소개",
+				"responsibility": "주요 업무",
+				"qualification": "자격 요건",
+				"preferredQualification": "우대사항"
+			}
+		}
+	},
 	"footer": {
 		"brand": "Bigtablet, Inc.",
 		"address": "(41585) 대구광역시 동구 동대구로 465, 대구스케일업허브 9층 912호",
@@ -384,7 +397,10 @@
 		"empty": "등록된 뉴스가 없습니다."
 	},
 	"blog": {
-		"empty": "등록된 블로그가 없습니다."
+		"empty": "등록된 블로그가 없습니다.",
+		"detail": {
+			"views": "조회"
+		}
 	},
 	"cookie": {
 		"message": "이 웹사이트는 더 나은 경험을 위해 쿠키를 사용합니다.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3,7 +3,28 @@
 		"backToHome": "홈으로",
 		"backToMain": "메인으로 돌아가기",
 		"backToList": "목록으로",
-		"backToTeam": "팀으로 돌아가기"
+		"backToListGeneric": "목록으로 돌아가기",
+		"backToTeam": "팀으로 돌아가기",
+		"backToBlog": "블로그 목록",
+		"backToBlogList": "블로그 목록으로 돌아가기",
+		"backToRecruit": "채용 목록",
+		"backToRecruitList": "채용 목록으로 돌아가기",
+		"backToAboutTeam": "팀 소개로 돌아가기"
+	},
+	"error": {
+		"title": "문제가 발생했습니다",
+		"description": "페이지를 불러오는 중 오류가 발생했습니다.\n잠시 후 다시 시도해 주세요.",
+		"retry": "다시 시도",
+		"globalDescription": "일시적인 오류가 발생했습니다.\n잠시 후 다시 시도해주세요.",
+		"retryCooldown": "{seconds}초 후 재시도",
+		"retryDisabled": "재시도 불가",
+		"retryProgress": "재시도 {current}/{max}",
+		"retryExceeded": "재시도 횟수를 초과했습니다.\n문제가 지속되면 관리자에게 문의해주세요.",
+		"goHome": "홈으로 이동",
+		"goBack": "이전 페이지",
+		"notFoundCode": "404",
+		"notFoundTitle": "페이지를 찾을 수 없습니다",
+		"notFoundDescription": "요청하신 페이지가 존재하지 않거나\n잘못된 접근입니다."
 	},
 	"footer": {
 		"brand": "Bigtablet, Inc.",

--- a/src/app/(i18n)/about/[id]/error.tsx
+++ b/src/app/(i18n)/about/[id]/error.tsx
@@ -1,15 +1,18 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
+import { useTranslations } from "next-intl";
 import { useEffect } from "react";
 import ErrorFallback from "src/shared/ui/error-fallback";
 
 const MemberDetailError = ({ error, reset }: { error: Error; reset: () => void }) => {
+	const t = useTranslations("common");
+
 	useEffect(() => {
 		Sentry.captureException(error);
 	}, [error]);
 
-	return <ErrorFallback reset={reset} backHref="/about" backLabel="팀 소개로 돌아가기" />;
+	return <ErrorFallback reset={reset} backHref="/about" backLabel={t("backToAboutTeam")} />;
 };
 
 export default MemberDetailError;

--- a/src/app/(i18n)/about/page.tsx
+++ b/src/app/(i18n)/about/page.tsx
@@ -25,7 +25,7 @@ const About = async () => {
 	 */
 	const store = await cookies();
 	const localeValue = store.get("NEXT_LOCALE")?.value?.toLowerCase();
-	const locale = localeValue === "en" ? "en" : "ko";
+	const locale = localeValue?.startsWith("en") ? "en" : "ko";
 
 	let aboutHistory: unknown = {};
 	try {

--- a/src/app/(i18n)/about/page.tsx
+++ b/src/app/(i18n)/about/page.tsx
@@ -1,25 +1,46 @@
-"use client";
-
-import { useMessages } from "next-intl";
+import { cookies } from "next/headers";
 import type { HistorySchema } from "src/entities/about/history/schema/history.schema";
 import History from "src/widgets/about/history";
 import Introduce from "src/widgets/about/introduce";
 import Team from "src/widgets/about/team";
+import { z } from "zod";
 
-type HistoryRawItem =
-	| string
-	| { title: string; id?: string; description?: string; dateLabel?: string };
+const historyItemSchema = z.union([
+	z.string(),
+	z.object({
+		title: z.string(),
+		id: z.string().optional(),
+		description: z.string().optional(),
+		dateLabel: z.string().optional(),
+	}),
+]);
 
-const About = () => {
-	const messages = useMessages() as Record<string, Record<string, unknown>>;
-	const historyByYear = ((messages?.about as Record<string, unknown>)?.history ?? {}) as Record<
-		string,
-		HistoryRawItem[]
-	>;
+const historyByYearSchema = z.record(z.string(), z.array(historyItemSchema));
+
+const About = async () => {
+	/**
+	 * (i18n) layout과 동일하게 NEXT_LOCALE 쿠키 기반으로 직접 import.
+	 * getMessages()는 middleware가 next-intl routing을 안 쓰는 환경에서
+	 * defaultLocale로 fallback되는 문제가 있음.
+	 */
+	const store = await cookies();
+	const localeValue = store.get("NEXT_LOCALE")?.value?.toLowerCase();
+	const locale = localeValue === "en" ? "en" : "ko";
+
+	let aboutHistory: unknown = {};
+	try {
+		const messages = (await import(`../../../../messages/${locale}.json`)).default;
+		aboutHistory = messages?.about?.history ?? {};
+	} catch {
+		aboutHistory = {};
+	}
+
+	const parsed = historyByYearSchema.safeParse(aboutHistory);
+	const historyByYear = parsed.success ? parsed.data : {};
 
 	const items: HistorySchema[] = Object.entries(historyByYear).flatMap(([year, list]) =>
-		(Array.isArray(list) ? list : []).map((it, idx) => {
-			const obj = typeof it === "string" ? { title: it } : it;
+		list.map((entry, idx) => {
+			const obj = typeof entry === "string" ? { title: entry } : entry;
 			const id = obj.id ?? `${year}-${String(idx + 1).padStart(2, "0")}`;
 			return {
 				id,

--- a/src/app/(i18n)/blog/[idx]/client.tsx
+++ b/src/app/(i18n)/blog/[idx]/client.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { notFound } from "next/navigation";
-import { useLocale } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useEffect, useRef } from "react";
 import remarkGfm from "remark-gfm";
 
@@ -26,6 +26,7 @@ const BlogDetailClient = ({ idx }: Props) => {
 	 * - 렌더마다 Hook 순서를 고정하기 위함
 	 */
 	const locale = useLocale();
+	const t = useTranslations("common");
 	const { data, isLoading, isError } = useBlogDetailQuery(idx);
 	const { mutate: incView } = useBlogViewMutation();
 	const firedRef = useRef(false);
@@ -68,7 +69,7 @@ const BlogDetailClient = ({ idx }: Props) => {
 
 	return (
 		<section className={styles.blog_detail}>
-			<BackLink href="/blog" label="블로그 목록" />
+			<BackLink href="/blog" label={t("backToBlog")} />
 
 			<article className={styles.blog_detail_body}>
 				<h1 className={styles.blog_detail_title}>{title}</h1>

--- a/src/app/(i18n)/blog/[idx]/client.tsx
+++ b/src/app/(i18n)/blog/[idx]/client.tsx
@@ -27,6 +27,7 @@ const BlogDetailClient = ({ idx }: Props) => {
 	 */
 	const locale = useLocale();
 	const t = useTranslations("common");
+	const tBlog = useTranslations("blog.detail");
 	const { data, isLoading, isError } = useBlogDetailQuery(idx);
 	const { mutate: incView } = useBlogViewMutation();
 	const firedRef = useRef(false);
@@ -78,7 +79,7 @@ const BlogDetailClient = ({ idx }: Props) => {
 					<span className={styles.blog_detail_time}>{time}</span>
 					<span className={styles.blog_detail_dot}>·</span>
 					<span className={styles.blog_detail_views}>
-						{(data.views ?? 0).toLocaleString()} views
+						{(data.views ?? 0).toLocaleString()} {tBlog("views")}
 					</span>
 				</div>
 

--- a/src/app/(i18n)/blog/[idx]/error.tsx
+++ b/src/app/(i18n)/blog/[idx]/error.tsx
@@ -1,15 +1,18 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
+import { useTranslations } from "next-intl";
 import { useEffect } from "react";
 import ErrorFallback from "src/shared/ui/error-fallback";
 
 const BlogDetailError = ({ error, reset }: { error: Error; reset: () => void }) => {
+	const t = useTranslations("common");
+
 	useEffect(() => {
 		Sentry.captureException(error);
 	}, [error]);
 
-	return <ErrorFallback reset={reset} backHref="/blog" backLabel="블로그 목록으로 돌아가기" />;
+	return <ErrorFallback reset={reset} backHref="/blog" backLabel={t("backToBlogList")} />;
 };
 
 export default BlogDetailError;

--- a/src/app/(i18n)/layout.tsx
+++ b/src/app/(i18n)/layout.tsx
@@ -8,7 +8,7 @@ import styles from "./layout.module.scss";
 
 export default async function LocaleLayout({ children }: { children: ReactNode }) {
 	const localeValue = (await cookies()).get("NEXT_LOCALE")?.value?.toLowerCase();
-	const locale = localeValue === "en" ? "en" : "ko"; // 기본 ko
+	const locale = localeValue?.startsWith("en") ? "en" : "ko"; // 기본 ko, 'en-US' 등 region code도 인식
 	const messages = (await import(`../../../messages/${locale}.json`)).default;
 
 	return (

--- a/src/app/(i18n)/main/page.tsx
+++ b/src/app/(i18n)/main/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Banner from "src/widgets/main/banner";
 import Collaborations from "src/widgets/main/collaborations";
 import Problem from "src/widgets/main/problem";

--- a/src/app/(i18n)/recruit/[idx]/client.tsx
+++ b/src/app/(i18n)/recruit/[idx]/client.tsx
@@ -15,7 +15,9 @@ import { toIdx } from "./utils";
 
 const RecruitDetailClient = () => {
 	const { idx } = useParams<{ locale: string; idx: string }>();
-	const t = useTranslations("common");
+	const tCommon = useTranslations("common");
+	const tDetail = useTranslations("recruit.detail");
+	const tSection = useTranslations("recruit.detail.section");
 	const idxNum = toIdx(idx);
 
 	const { data, status, error } = useRecruitDetailQuery(idxNum ?? -1, {
@@ -26,25 +28,42 @@ const RecruitDetailClient = () => {
 
 	return (
 		<div className={styles.recruit_detail}>
-			<BackLink href="/recruit" label={t("backToRecruit")} />
+			<BackLink href="/recruit" label={tCommon("backToRecruit")} />
 
-			{status === "pending" && <div className={styles.recruit_detail_loading}>불러오는 중…</div>}
+			{status === "pending" && (
+				<div className={styles.recruit_detail_loading}>{tDetail("loading")}</div>
+			)}
 
 			{status === "error" && (
 				<div className={styles.recruit_detail_error}>
-					불러오지 못했습니다. {error instanceof Error ? error.message : ""}
+					{tDetail("loadFailed")} {error instanceof Error ? error.message : ""}
 				</div>
 			)}
 
 			{status === "success" && recruit && (
 				<>
 					<RecruitHeader recruit={recruit} />
-					<RecruitMarkdownSection title="조직 소개" content={recruit.companyIntroduction} />
-					<RecruitMarkdownSection title="포지션 소개" content={recruit.positionIntroduction} />
-					<RecruitMarkdownSection title="주요 업무" content={recruit.mainResponsibility} />
-					<RecruitMarkdownSection title="자격 요건" content={recruit.qualification} />
+					<RecruitMarkdownSection
+						title={tSection("company")}
+						content={recruit.companyIntroduction}
+					/>
+					<RecruitMarkdownSection
+						title={tSection("position")}
+						content={recruit.positionIntroduction}
+					/>
+					<RecruitMarkdownSection
+						title={tSection("responsibility")}
+						content={recruit.mainResponsibility}
+					/>
+					<RecruitMarkdownSection
+						title={tSection("qualification")}
+						content={recruit.qualification}
+					/>
 					{recruit.preferredQualification && (
-						<RecruitMarkdownSection title="우대사항" content={recruit.preferredQualification} />
+						<RecruitMarkdownSection
+							title={tSection("preferredQualification")}
+							content={recruit.preferredQualification}
+						/>
 					)}
 					<RecruitBenefits />
 					<RecruitProcess />

--- a/src/app/(i18n)/recruit/[idx]/client.tsx
+++ b/src/app/(i18n)/recruit/[idx]/client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useParams } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useRecruitDetailQuery } from "src/features/recruit/query/recruit.query";
 import BackLink from "src/shared/ui/back-link";
 import { RecruitBenefits } from "./recruit-benefits";
@@ -14,6 +15,7 @@ import { toIdx } from "./utils";
 
 const RecruitDetailClient = () => {
 	const { idx } = useParams<{ locale: string; idx: string }>();
+	const t = useTranslations("common");
 	const idxNum = toIdx(idx);
 
 	const { data, status, error } = useRecruitDetailQuery(idxNum ?? -1, {
@@ -24,7 +26,7 @@ const RecruitDetailClient = () => {
 
 	return (
 		<div className={styles.recruit_detail}>
-			<BackLink href="/recruit" label="채용 목록" />
+			<BackLink href="/recruit" label={t("backToRecruit")} />
 
 			{status === "pending" && <div className={styles.recruit_detail_loading}>불러오는 중…</div>}
 

--- a/src/app/(i18n)/recruit/[idx]/error.tsx
+++ b/src/app/(i18n)/recruit/[idx]/error.tsx
@@ -1,15 +1,18 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
+import { useTranslations } from "next-intl";
 import { useEffect } from "react";
 import ErrorFallback from "src/shared/ui/error-fallback";
 
 const RecruitDetailError = ({ error, reset }: { error: Error; reset: () => void }) => {
+	const t = useTranslations("common");
+
 	useEffect(() => {
 		Sentry.captureException(error);
 	}, [error]);
 
-	return <ErrorFallback reset={reset} backHref="/recruit" backLabel="채용 목록으로 돌아가기" />;
+	return <ErrorFallback reset={reset} backHref="/recruit" backLabel={t("backToRecruitList")} />;
 };
 
 export default RecruitDetailError;

--- a/src/app/(i18n)/recruit/page-client.tsx
+++ b/src/app/(i18n)/recruit/page-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import type { RecruitSearchFilters } from "src/entities/recruit/api/recruit.api";
@@ -9,6 +10,7 @@ import RequestList from "src/widgets/recruit/main/list";
 import styles from "./style.module.scss";
 
 const RecruitPageClient = () => {
+	const t = useTranslations("common");
 	const [filters, setFilters] = useState<RecruitSearchFilters>({
 		keyword: "",
 		job: "",
@@ -26,7 +28,7 @@ const RecruitPageClient = () => {
 						<ErrorFallback
 							reset={resetErrorBoundary}
 							backHref="/main"
-							backLabel="메인으로 돌아가기"
+							backLabel={t("backToMain")}
 						/>
 					)}
 					resetKeys={[filters]}

--- a/src/app/error.module.scss
+++ b/src/app/error.module.scss
@@ -31,6 +31,7 @@
 	font-size: token.$font_size_sm;
 	color: token.$text_subtle;
 	line-height: token.$line_height_relaxed;
+	white-space: pre-line;
 }
 
 .error_retry_count {
@@ -42,6 +43,7 @@
 	font-size: token.$font_size_sm;
 	color: token.$color_error;
 	line-height: token.$line_height_relaxed;
+	white-space: pre-line;
 }
 
 .error_actions {

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@bigtablet/design-system";
 import * as Sentry from "@sentry/nextjs";
+import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
 import Template from "src/shared/ui/template";
 import styles from "./error.module.scss";
@@ -15,6 +16,7 @@ const COOLDOWN_SEC = 3;
  * - router 훅은 에러 바운더리에서 불안정하므로 window.location 사용
  */
 const GlobalError = ({ error: _error, reset }: { error: Error; reset: () => void }) => {
+	const t = useTranslations("error");
 	const [retryCount, setRetryCount] = useState(0);
 	const [cooldown, setCooldown] = useState(0);
 	const timerRef = useRef<ReturnType<typeof setInterval>>(undefined);
@@ -56,42 +58,32 @@ const GlobalError = ({ error: _error, reset }: { error: Error; reset: () => void
 	};
 
 	const retryLabel = isCooling
-		? `${cooldown}초 후 재시도`
+		? t("retryCooldown", { seconds: cooldown })
 		: isMaxRetry
-			? "재시도 불가"
-			: "다시 시도";
+			? t("retryDisabled")
+			: t("retry");
 
 	return (
 		<Template align="center">
 			<section className={styles.error_root}>
 				<p className={styles.error_emoji}>!</p>
-				<h1 className={styles.error_title}>문제가 발생했습니다</h1>
-				<p className={styles.error_desc}>
-					일시적인 오류가 발생했습니다.
-					<br />
-					잠시 후 다시 시도해주세요.
-				</p>
+				<h1 className={styles.error_title}>{t("title")}</h1>
+				<p className={styles.error_desc}>{t("globalDescription")}</p>
 
 				{!isMaxRetry && retryCount > 0 && (
 					<p className={styles.error_retry_count}>
-						재시도 {retryCount}/{MAX_RETRY}
+						{t("retryProgress", { current: retryCount, max: MAX_RETRY })}
 					</p>
 				)}
 
-				{isMaxRetry && (
-					<p className={styles.error_max}>
-						재시도 횟수를 초과했습니다.
-						<br />
-						문제가 지속되면 관리자에게 문의해주세요.
-					</p>
-				)}
+				{isMaxRetry && <p className={styles.error_max}>{t("retryExceeded")}</p>}
 
 				<div className={styles.error_actions}>
 					<Button variant="primary" onClick={handleRetry} disabled={isCooling || isMaxRetry}>
 						{retryLabel}
 					</Button>
 					<Button variant="secondary" onClick={handleHome}>
-						홈으로 이동
+						{t("goHome")}
 					</Button>
 				</div>
 			</section>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ export const dynamic = "force-dynamic";
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
 	const store = await cookies();
 	const value = store.get("NEXT_LOCALE")?.value?.toLowerCase();
-	const locale = (value === "en" ? "en" : "ko") as "en" | "ko";
+	const locale = (value?.startsWith("en") ? "en" : "ko") as "en" | "ko";
 
 	/**
 	 * 쿠키 기반으로 직접 messages 로드. (i18n) layout과 동일한 로직.

--- a/src/app/not-found.module.scss
+++ b/src/app/not-found.module.scss
@@ -31,6 +31,7 @@
 	font-size: token.$font_size_sm;
 	color: token.$text_subtle;
 	line-height: token.$line_height_relaxed;
+	white-space: pre-line;
 }
 
 .actions {

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@bigtablet/design-system";
+import { useTranslations } from "next-intl";
 import { BigtabletRouter } from "src/shared/hooks/next";
 import Template from "src/shared/ui/template";
 import styles from "./not-found.module.scss";
@@ -11,6 +12,7 @@ import styles from "./not-found.module.scss";
  * - notFound() 호출 시 자동 표시
  */
 const NotFoundPage = () => {
+	const t = useTranslations("error");
 	const router = BigtabletRouter();
 
 	const handleBack = () => {
@@ -26,20 +28,16 @@ const NotFoundPage = () => {
 	return (
 		<Template align="center">
 			<section className={styles.root}>
-				<p className={styles.code}>404</p>
-				<h1 className={styles.title}>페이지를 찾을 수 없습니다</h1>
-				<p className={styles.desc}>
-					요청하신 페이지가 존재하지 않거나
-					<br />
-					잘못된 접근입니다.
-				</p>
+				<p className={styles.code}>{t("notFoundCode")}</p>
+				<h1 className={styles.title}>{t("notFoundTitle")}</h1>
+				<p className={styles.desc}>{t("notFoundDescription")}</p>
 
 				<div className={styles.actions}>
 					<Button variant="primary" onClick={handleHome}>
-						홈으로 이동
+						{t("goHome")}
 					</Button>
 					<Button variant="secondary" onClick={handleBack}>
-						이전 페이지
+						{t("goBack")}
 					</Button>
 				</div>
 			</section>

--- a/src/shared/ui/error-fallback/index.tsx
+++ b/src/shared/ui/error-fallback/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@bigtablet/design-system";
+import { useTranslations } from "next-intl";
 import { BigtabletLink } from "src/shared/hooks/next";
 import styles from "./style.module.scss";
 
@@ -9,33 +10,28 @@ interface ErrorFallbackProps {
 	reset: () => void;
 	/** 목록 페이지로 돌아가기 링크 */
 	backHref?: string;
-	/** 돌아가기 버튼 텍스트 */
+	/** 돌아가기 버튼 텍스트. 미지정 시 common.backToListGeneric 사용 */
 	backLabel?: string;
 }
 
 /** 세그먼트 에러 바운더리 공용 UI */
-const ErrorFallback = ({
-	reset,
-	backHref,
-	backLabel = "목록으로 돌아가기",
-}: ErrorFallbackProps) => {
+const ErrorFallback = ({ reset, backHref, backLabel }: ErrorFallbackProps) => {
+	const t = useTranslations("error");
+	const tCommon = useTranslations("common");
+
 	return (
 		<div className={styles.error_fallback} role="alert">
-			<h2 className={styles.error_fallback_title}>문제가 발생했습니다</h2>
-			<p className={styles.error_fallback_desc}>
-				페이지를 불러오는 중 오류가 발생했습니다.
-				<br />
-				잠시 후 다시 시도해 주세요.
-			</p>
+			<h2 className={styles.error_fallback_title}>{t("title")}</h2>
+			<p className={styles.error_fallback_desc}>{t("description")}</p>
 
 			<div className={styles.error_fallback_actions}>
 				<Button variant="primary" onClick={() => reset()}>
-					다시 시도
+					{t("retry")}
 				</Button>
 
 				{backHref && (
 					<BigtabletLink href={backHref} className={styles.error_fallback_back}>
-						{backLabel}
+						{backLabel ?? tCommon("backToListGeneric")}
 					</BigtabletLink>
 				)}
 			</div>

--- a/src/shared/ui/error-fallback/style.module.scss
+++ b/src/shared/ui/error-fallback/style.module.scss
@@ -22,6 +22,7 @@
     color: token.$text_normal;
     line-height: token.$line_height_normal;
     margin-bottom: token.$spacing_2xl;
+    white-space: pre-line;
 }
 
 .error_fallback_actions {

--- a/src/widgets/main/collaborations/index.tsx
+++ b/src/widgets/main/collaborations/index.tsx
@@ -32,6 +32,7 @@ const Collaborations = () => {
 								<Image
 									src={src}
 									alt=""
+									aria-hidden="true"
 									width={260}
 									height={60}
 									sizes="(max-width: 768px) 180px, 280px"

--- a/src/widgets/news/card/index.tsx
+++ b/src/widgets/news/card/index.tsx
@@ -38,7 +38,7 @@ const NewsCard = ({
 				className={styles.news_card_thumb}
 				imgClassName={styles.news_card_img}
 				src={imageSrc ?? undefined}
-				alt=""
+				alt={title}
 				sizes="(max-width: 768px) 100vw, 33vw"
 				priority={priority}
 			/>


### PR DESCRIPTION
## 제목
fix/server-components-and-i18n-coverage

## 작업한 내용

### Server Components
- [x] /main 페이지 "use client" 제거 (정적 위젯 composer만 함)
- [x] /about 페이지 server component 전환 + cookie 기반 직접 messages import + Zod 검증
- [x] /about에서 영문 history 데이터가 한글 뷰에 누출되던 버그 수정

### i18n
- [x] common namespace 키 추가 (backToBlog, backToBlogList, backToRecruit, backToRecruitList, backToAboutTeam, backToListGeneric)
- [x] error namespace 신설 (title, description, retry 등)
- [x] ErrorFallback useTranslations 적용
- [x] /recruit, /blog/[idx], /recruit/[idx], /about/[id] 에러/클라이언트 페이지 한글 하드코딩 → useTranslations
- [x] root error.tsx, not-found.tsx i18n 적용
- [x] white-space: pre-line 추가 (\n 줄바꿈 렌더링)

### a11y
- [x] collaborations 파트너 로고 aria-hidden="true"
- [x] news card thumbnail alt를 article title로

## 전달할 추가 이슈
- 없음

Closes #308