### PR TITLE
refactor/low-cleanup

### DIFF
--- a/src/app/(i18n)/blog/[idx]/loading.tsx
+++ b/src/app/(i18n)/blog/[idx]/loading.tsx
@@ -1,0 +1,13 @@
+import styles from "./style.module.scss";
+
+/**
+ * @description
+ * /blog/[idx] segment loading. SSR prefetchQuery 동안 즉시 스트리밍되는 셸.
+ */
+const BlogDetailLoading = () => (
+	<div className={styles.blog_detail}>
+		<div className={styles.blog_detail_loading}>...</div>
+	</div>
+);
+
+export default BlogDetailLoading;

--- a/src/app/(i18n)/blog/[idx]/loading.tsx
+++ b/src/app/(i18n)/blog/[idx]/loading.tsx
@@ -1,3 +1,4 @@
+import SkeletonDetail from "src/shared/ui/skeleton/detail";
 import styles from "./style.module.scss";
 
 /**
@@ -6,7 +7,7 @@ import styles from "./style.module.scss";
  */
 const BlogDetailLoading = () => (
 	<div className={styles.blog_detail}>
-		<div className={styles.blog_detail_loading}>...</div>
+		<SkeletonDetail />
 	</div>
 );
 

--- a/src/app/(i18n)/blog/loading.tsx
+++ b/src/app/(i18n)/blog/loading.tsx
@@ -1,0 +1,15 @@
+import BlogListSkeleton from "src/widgets/blog/list/skeleton";
+import styles from "./style.module.scss";
+
+/**
+ * @description
+ * /blog 라우트 segment loading. 서버 prefetch 진행 중 즉시 스트리밍되는 셸.
+ * page.tsx의 await prefetchQuery 동안 사용자에게 즉시 시각 피드백 제공.
+ */
+const BlogLoading = () => (
+	<div className={styles.blog_page}>
+		<BlogListSkeleton />
+	</div>
+);
+
+export default BlogLoading;

--- a/src/app/(i18n)/news/loading.tsx
+++ b/src/app/(i18n)/news/loading.tsx
@@ -1,0 +1,14 @@
+import NewsListSkeleton from "src/widgets/news/list/skeleton";
+import styles from "./style.module.scss";
+
+/**
+ * @description
+ * /news 라우트 segment loading. 서버 prefetch 진행 중 즉시 스트리밍되는 셸.
+ */
+const NewsLoading = () => (
+	<div className={styles.news_page}>
+		<NewsListSkeleton />
+	</div>
+);
+
+export default NewsLoading;

--- a/src/app/(i18n)/recruit/[idx]/apply/page.tsx
+++ b/src/app/(i18n)/recruit/[idx]/apply/page.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useParams } from "next/navigation";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { type Resolver, useForm } from "react-hook-form";
 import useEmailVerification from "src/features/recruit/apply/form/email/use-email-verification";
 
@@ -16,7 +16,7 @@ import styles from "./style.module.scss";
 
 const ApplyPage = () => {
 	const { idx } = useParams<{ locale: string; idx: string }>();
-	const jobId = useMemo(() => Number(idx) || -1, [idx]);
+	const jobId = Number(idx) || -1;
 
 	const form = useForm<ApplyFormValues>({
 		resolver: zodResolver(applySchema) as Resolver<ApplyFormValues>,

--- a/src/app/(i18n)/recruit/[idx]/client.tsx
+++ b/src/app/(i18n)/recruit/[idx]/client.tsx
@@ -4,12 +4,12 @@ import { useParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useRecruitDetailQuery } from "src/features/recruit/query/recruit.query";
 import BackLink from "src/shared/ui/back-link";
-import { RecruitBenefits } from "./recruit-benefits";
-import { RecruitHeader } from "./recruit-header";
-import { RecruitMarkdownSection } from "./recruit-markdown-section";
-import { RecruitNotice } from "./recruit-notice";
-import { RecruitProcess } from "./recruit-process";
-import { RecruitRequestSection } from "./recruit-request-section";
+import { RecruitBenefits } from "./sections/recruit-benefits";
+import { RecruitHeader } from "./sections/recruit-header";
+import { RecruitMarkdownSection } from "./sections/recruit-markdown-section";
+import { RecruitNotice } from "./sections/recruit-notice";
+import { RecruitProcess } from "./sections/recruit-process";
+import { RecruitRequestSection } from "./sections/recruit-request-section";
 import styles from "./style.module.scss";
 import { toIdx } from "./utils";
 

--- a/src/app/(i18n)/recruit/[idx]/loading.tsx
+++ b/src/app/(i18n)/recruit/[idx]/loading.tsx
@@ -1,0 +1,13 @@
+import styles from "./style.module.scss";
+
+/**
+ * @description
+ * /recruit/[idx] segment loading. SSR prefetchQuery 동안 즉시 스트리밍되는 셸.
+ */
+const RecruitDetailLoading = () => (
+	<div className={styles.recruit_detail}>
+		<div className={styles.recruit_detail_loading}>...</div>
+	</div>
+);
+
+export default RecruitDetailLoading;

--- a/src/app/(i18n)/recruit/[idx]/loading.tsx
+++ b/src/app/(i18n)/recruit/[idx]/loading.tsx
@@ -1,3 +1,4 @@
+import SkeletonDetail from "src/shared/ui/skeleton/detail";
 import styles from "./style.module.scss";
 
 /**
@@ -6,7 +7,7 @@ import styles from "./style.module.scss";
  */
 const RecruitDetailLoading = () => (
 	<div className={styles.recruit_detail}>
-		<div className={styles.recruit_detail_loading}>...</div>
+		<SkeletonDetail />
 	</div>
 );
 

--- a/src/app/(i18n)/recruit/[idx]/sections/recruit-benefits.tsx
+++ b/src/app/(i18n)/recruit/[idx]/sections/recruit-benefits.tsx
@@ -3,8 +3,8 @@
  * Recruit benefits section component.
  */
 
-import { BENEFITS } from "./constants";
-import styles from "./style.module.scss";
+import { BENEFITS } from "../constants";
+import styles from "../style.module.scss";
 
 /**
  * Displays employee benefits list.

--- a/src/app/(i18n)/recruit/[idx]/sections/recruit-header.tsx
+++ b/src/app/(i18n)/recruit/[idx]/sections/recruit-header.tsx
@@ -4,8 +4,8 @@
  */
 
 import type { RecruitCard } from "src/entities/recruit/schema/recruit.schema";
-import styles from "./style.module.scss";
-import { formatDate } from "./utils";
+import styles from "../style.module.scss";
+import { formatDate } from "../utils";
 
 /**
  * Props for RecruitHeader component.

--- a/src/app/(i18n)/recruit/[idx]/sections/recruit-markdown-section.tsx
+++ b/src/app/(i18n)/recruit/[idx]/sections/recruit-markdown-section.tsx
@@ -5,8 +5,8 @@
 
 import dynamic from "next/dynamic";
 import remarkBreaks from "remark-breaks";
-import { markdownComponents } from "./markdown-components";
-import styles from "./style.module.scss";
+import { markdownComponents } from "../markdown-components";
+import styles from "../style.module.scss";
 
 const ReactMarkdown = dynamic(() => import("react-markdown"), { ssr: false });
 

--- a/src/app/(i18n)/recruit/[idx]/sections/recruit-notice.tsx
+++ b/src/app/(i18n)/recruit/[idx]/sections/recruit-notice.tsx
@@ -3,7 +3,7 @@
  * Recruit notice section component.
  */
 
-import styles from "./style.module.scss";
+import styles from "../style.module.scss";
 
 /**
  * Displays notice section with hiring requirements and disclaimers.

--- a/src/app/(i18n)/recruit/[idx]/sections/recruit-process.tsx
+++ b/src/app/(i18n)/recruit/[idx]/sections/recruit-process.tsx
@@ -3,8 +3,8 @@
  * Recruit hiring process section component.
  */
 
-import { HIRING_PROCESS } from "./constants";
-import styles from "./style.module.scss";
+import { HIRING_PROCESS } from "../constants";
+import styles from "../style.module.scss";
 
 /**
  * Displays hiring process steps and additional information.

--- a/src/app/(i18n)/recruit/[idx]/sections/recruit-request-section.tsx
+++ b/src/app/(i18n)/recruit/[idx]/sections/recruit-request-section.tsx
@@ -5,7 +5,7 @@
 
 import { Button } from "@bigtablet/design-system";
 import { BigtabletLink } from "src/shared/hooks/next";
-import styles from "./style.module.scss";
+import styles from "../style.module.scss";
 
 /**
  * Props for RecruitRequestSection component.

--- a/src/app/(i18n)/recruit/loading.tsx
+++ b/src/app/(i18n)/recruit/loading.tsx
@@ -1,0 +1,20 @@
+import { SkeletonList } from "src/shared/ui/skeleton/list";
+import styles from "./style.module.scss";
+
+const SKELETON_KEYS = ["s0", "s1", "s2", "s3", "s4"];
+
+/**
+ * @description
+ * /recruit 라우트 segment loading. SSR prefetchQuery 진행 중 즉시 스트리밍.
+ */
+const RecruitLoading = () => (
+	<section className={styles.recruit_page}>
+		<div className={styles.recruit_page_list}>
+			{SKELETON_KEYS.map((key) => (
+				<SkeletonList key={key} />
+			))}
+		</div>
+	</section>
+);
+
+export default RecruitLoading;

--- a/src/features/recruit/apply/form/model/apply.util.ts
+++ b/src/features/recruit/apply/form/model/apply.util.ts
@@ -1,19 +1,3 @@
-import { ApplyMilitaryStatus } from "src/entities/recruit/schema/recruit.schema";
-
-/**
- * @description 현재 연도-월을 "YYYY-MM" 형식으로 반환한다.
- *
- * @returns "2026-04" 등의 문자열
- *
- * @example
- * currentYearMonth() // "2026-04"
- */
-export const currentYearMonth = () => {
-	const date = new Date();
-	const month = `${date.getMonth() + 1}`.padStart(2, "0");
-	return `${date.getFullYear()}-${month}`;
-};
-
 /**
  * @description 전화번호를 010-XXXX-XXXX 형식으로 포맷팅한다.
  * 010으로 시작하지 않으면 자동 교체하고 11자리로 제한한다.
@@ -35,26 +19,3 @@ export const formatPhone010 = (input: string) => {
 	if (digits.length > 7) return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
 	return digits;
 };
-
-/**
- * @description 병역 상태 문자열을 ApplyMilitaryStatus enum으로 매핑한다.
- * 레거시 값("DONE", "PENDING", "EXEMPT")도 호환 처리한다.
- *
- * @param value - 병역 상태 문자열
- * @returns ApplyMilitaryStatus enum 값
- *
- * @example
- * mapMil("DONE")    // "COMPLETED"
- * mapMil("PENDING") // "NOT_COMPLETED"
- * mapMil("UNKNOWN") // "NOT_APPLICABLE"
- */
-export const mapMil = (value: string): ApplyMilitaryStatus => {
-	if (value === "DONE") return ApplyMilitaryStatus.enum.COMPLETED;
-	if (value === "PENDING") return ApplyMilitaryStatus.enum.NOT_COMPLETED;
-	if (value === "EXEMPT" || value === "") return ApplyMilitaryStatus.enum.NOT_APPLICABLE;
-	const parsed = ApplyMilitaryStatus.safeParse(value);
-	if (parsed.success) return parsed.data;
-	return ApplyMilitaryStatus.enum.NOT_APPLICABLE;
-};
-
-export default { currentYearMonth, formatPhone010, mapMil };

--- a/src/features/recruit/test/apply.util.test.ts
+++ b/src/features/recruit/test/apply.util.test.ts
@@ -1,23 +1,5 @@
-import { ApplyMilitaryStatus } from "src/entities/recruit/schema/recruit.schema";
-import {
-	currentYearMonth,
-	formatPhone010,
-	mapMil,
-} from "src/features/recruit/apply/form/model/apply.util";
+import { formatPhone010 } from "src/features/recruit/apply/form/model/apply.util";
 import { describe, expect, it } from "vitest";
-
-describe("currentYearMonth", () => {
-	it("YYYY-MM 형식 반환", () => {
-		const result = currentYearMonth();
-		expect(result).toMatch(/^\d{4}-\d{2}$/);
-	});
-
-	it("현재 연도와 월 반환", () => {
-		const date = new Date();
-		const expected = `${date.getFullYear()}-${`${date.getMonth() + 1}`.padStart(2, "0")}`;
-		expect(currentYearMonth()).toBe(expected);
-	});
-});
 
 describe("formatPhone010", () => {
 	it("010으로 시작하는 번호 포맷팅 — 7자리 이하", () => {
@@ -45,33 +27,5 @@ describe("formatPhone010", () => {
 
 	it("숫자가 3자리 이하면 포맷 없이 반환", () => {
 		expect(formatPhone010("01")).toBe("010");
-	});
-});
-
-describe("mapMil", () => {
-	it("DONE → COMPLETED", () => {
-		expect(mapMil("DONE")).toBe(ApplyMilitaryStatus.enum.COMPLETED);
-	});
-
-	it("PENDING → NOT_COMPLETED", () => {
-		expect(mapMil("PENDING")).toBe(ApplyMilitaryStatus.enum.NOT_COMPLETED);
-	});
-
-	it("EXEMPT → NOT_APPLICABLE", () => {
-		expect(mapMil("EXEMPT")).toBe(ApplyMilitaryStatus.enum.NOT_APPLICABLE);
-	});
-
-	it("빈 문자열 → NOT_APPLICABLE", () => {
-		expect(mapMil("")).toBe(ApplyMilitaryStatus.enum.NOT_APPLICABLE);
-	});
-
-	it("유효한 enum 값을 직접 전달하면 그대로 반환한다", () => {
-		expect(mapMil("COMPLETED")).toBe(ApplyMilitaryStatus.enum.COMPLETED);
-		expect(mapMil("NOT_COMPLETED")).toBe(ApplyMilitaryStatus.enum.NOT_COMPLETED);
-		expect(mapMil("NOT_APPLICABLE")).toBe(ApplyMilitaryStatus.enum.NOT_APPLICABLE);
-	});
-
-	it("알 수 없는 값 → NOT_APPLICABLE (fallback)", () => {
-		expect(mapMil("UNKNOWN")).toBe(ApplyMilitaryStatus.enum.NOT_APPLICABLE);
 	});
 });

--- a/src/shared/libs/api/zod/index.ts
+++ b/src/shared/libs/api/zod/index.ts
@@ -2,6 +2,7 @@ import BigtabletAxios from "src/shared/libs/api/axios";
 import type { z } from "zod";
 
 type AxiosConfig = Record<string, unknown>;
+type WriteMethod = "post" | "put" | "patch" | "delete";
 
 /**
  * @description
@@ -37,79 +38,50 @@ export const getParsed = async <S extends z.ZodTypeAny>(
 };
 
 /**
- * @description POST 요청 후 Zod 스키마로 응답을 파싱한다.
- *
- * @param url - 요청 URL
- * @param schema - 응답 검증용 Zod 스키마
- * @param body - 요청 본문
- * @param config - Axios 설정
- * @returns 스키마로 파싱된 응답 데이터
- * @throws Zod 파싱 실패 시 ZodError
+ * @description body를 동반하는 write 메서드(POST/PUT/PATCH/DELETE) 공용 helper.
+ * Axios 메서드별 시그니처 차이를 흡수하고 응답을 Zod 스키마로 파싱한다.
  */
-export const postParsed = async <S extends z.ZodTypeAny>(
+const writeParsed = async <S extends z.ZodTypeAny>(
+	method: WriteMethod,
 	url: string,
 	schema: S,
 	body?: unknown,
 	config?: AxiosConfig,
 ): Promise<z.infer<S>> => {
-	const response = await BigtabletAxios.post<unknown>(url, body, config);
+	const response =
+		method === "delete"
+			? await BigtabletAxios.delete<unknown>(url, config)
+			: await BigtabletAxios[method]<unknown>(url, body, config);
 	return schema.parse(response.data);
 };
 
-/**
- * @description PUT 요청 후 Zod 스키마로 응답을 파싱한다.
- *
- * @param url - 요청 URL
- * @param schema - 응답 검증용 Zod 스키마
- * @param body - 요청 본문
- * @param config - Axios 설정
- * @returns 스키마로 파싱된 응답 데이터
- * @throws Zod 파싱 실패 시 ZodError
- */
-export const putParsed = async <S extends z.ZodTypeAny>(
+/** POST 요청 후 Zod 스키마로 응답을 파싱한다. */
+export const postParsed = <S extends z.ZodTypeAny>(
 	url: string,
 	schema: S,
 	body?: unknown,
 	config?: AxiosConfig,
-): Promise<z.infer<S>> => {
-	const response = await BigtabletAxios.put<unknown>(url, body, config);
-	return schema.parse(response.data);
-};
+) => writeParsed("post", url, schema, body, config);
 
-/**
- * @description PATCH 요청 후 Zod 스키마로 응답을 파싱한다.
- *
- * @param url - 요청 URL
- * @param schema - 응답 검증용 Zod 스키마
- * @param body - 요청 본문
- * @param config - Axios 설정
- * @returns 스키마로 파싱된 응답 데이터
- * @throws Zod 파싱 실패 시 ZodError
- */
-export const patchParsed = async <S extends z.ZodTypeAny>(
+/** PUT 요청 후 Zod 스키마로 응답을 파싱한다. */
+export const putParsed = <S extends z.ZodTypeAny>(
 	url: string,
 	schema: S,
 	body?: unknown,
 	config?: AxiosConfig,
-): Promise<z.infer<S>> => {
-	const response = await BigtabletAxios.patch<unknown>(url, body, config);
-	return schema.parse(response.data);
-};
+) => writeParsed("put", url, schema, body, config);
 
-/**
- * @description DELETE 요청 후 Zod 스키마로 응답을 파싱한다.
- *
- * @param url - 요청 URL
- * @param schema - 응답 검증용 Zod 스키마
- * @param config - Axios 설정
- * @returns 스키마로 파싱된 응답 데이터
- * @throws Zod 파싱 실패 시 ZodError
- */
-export const deleteParsed = async <S extends z.ZodTypeAny>(
+/** PATCH 요청 후 Zod 스키마로 응답을 파싱한다. */
+export const patchParsed = <S extends z.ZodTypeAny>(
+	url: string,
+	schema: S,
+	body?: unknown,
+	config?: AxiosConfig,
+) => writeParsed("patch", url, schema, body, config);
+
+/** DELETE 요청 후 Zod 스키마로 응답을 파싱한다. */
+export const deleteParsed = <S extends z.ZodTypeAny>(
 	url: string,
 	schema: S,
 	config?: AxiosConfig,
-): Promise<z.infer<S>> => {
-	const response = await BigtabletAxios.delete<unknown>(url, config);
-	return schema.parse(response.data);
-};
+) => writeParsed("delete", url, schema, undefined, config);

--- a/src/shared/libs/api/zod/index.ts
+++ b/src/shared/libs/api/zod/index.ts
@@ -51,8 +51,8 @@ const writeParsed = async <S extends z.ZodTypeAny>(
 	const response =
 		method === "delete"
 			? await BigtabletAxios.delete<unknown>(url, config)
-			: await BigtabletAxios[method]<unknown>(url, body, config);
-	return schema.parse(response.data);
+			: await BigtabletAxios[method as "post" | "put" | "patch"]<unknown>(url, body, config);
+	return handleNoContent(response.status, response.data, schema);
 };
 
 /** POST 요청 후 Zod 스키마로 응답을 파싱한다. */

--- a/src/shared/ui/back-link/index.tsx
+++ b/src/shared/ui/back-link/index.tsx
@@ -32,7 +32,7 @@ const BackLink = ({ href, label }: Props) => {
 
 	return (
 		<a className={styles.back_link} href={href ?? "#"} onClick={handleClick}>
-			← {label}
+			<span aria-hidden="true">←</span> {label}
 		</a>
 	);
 };

--- a/src/shared/ui/header/index.tsx
+++ b/src/shared/ui/header/index.tsx
@@ -32,8 +32,9 @@ const Header = () => {
 		return () => window.removeEventListener("scroll", onScroll);
 	}, []);
 
+	/* 경로 변경 시 모바일 메뉴 자동 닫기 */
+	// biome-ignore lint/correctness/useExhaustiveDependencies: pathname 변경이 트리거 — 본문에선 미사용
 	useEffect(() => {
-		void pathname;
 		setMenuOpen(false);
 	}, [pathname]);
 

--- a/src/shared/ui/skeleton/detail/index.tsx
+++ b/src/shared/ui/skeleton/detail/index.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import styles from "./style.module.scss";
+
+/**
+ * @description
+ * 상세 페이지 셸 스켈레톤 — 제목 + 메타 + 본문 라인.
+ * blog/[idx], recruit/[idx] 등 SSR prefetch 동안 즉시 시각 피드백 제공.
+ */
+const SkeletonDetail = () => (
+	<div className={styles.detail_skeleton}>
+		<div className={`${styles.detail_skeleton_line} ${styles.title}`} />
+		<div className={`${styles.detail_skeleton_line} ${styles.meta}`} />
+		<div className={styles.detail_skeleton_thumb} />
+		<div className={styles.detail_skeleton_body}>
+			<div className={styles.detail_skeleton_line} />
+			<div className={styles.detail_skeleton_line} />
+			<div className={`${styles.detail_skeleton_line} ${styles.short}`} />
+			<div className={styles.detail_skeleton_line} />
+			<div className={`${styles.detail_skeleton_line} ${styles.medium}`} />
+		</div>
+	</div>
+);
+
+export default SkeletonDetail;

--- a/src/shared/ui/skeleton/detail/style.module.scss
+++ b/src/shared/ui/skeleton/detail/style.module.scss
@@ -1,0 +1,56 @@
+@use "@bigtablet/design-system/scss/token" as token;
+
+.detail_skeleton {
+  @include token.flex_column;
+  width: 100%;
+  gap: token.$spacing_md;
+  animation: detail_skeleton_pulse 1.5s ease-in-out infinite;
+}
+
+.detail_skeleton_line {
+  height: 1rem;
+  background: token.$color_background_secondary;
+  border-radius: token.$radius_sm;
+}
+
+.title {
+  height: 2.25rem;
+  width: 70%;
+}
+
+.meta {
+  height: 0.875rem;
+  width: 40%;
+  margin-bottom: token.$spacing_md;
+}
+
+.detail_skeleton_thumb {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background: token.$color_background_secondary;
+  border-radius: token.$radius_md;
+  margin-bottom: token.$spacing_lg;
+}
+
+.detail_skeleton_body {
+  @include token.flex_column;
+  gap: token.$spacing_sm;
+}
+
+.short {
+  width: 55%;
+}
+
+.medium {
+  width: 80%;
+}
+
+@keyframes detail_skeleton_pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}

--- a/src/widgets/about/introduce/style.module.scss
+++ b/src/widgets/about/introduce/style.module.scss
@@ -10,6 +10,11 @@
     flex-direction: row-reverse;
   }
 
+  /* 인접한 introduce 끼리 padding-top 제거 — 4xl + 4xl 누적으로 갭 과대 */
+  & + .introduce {
+    padding-top: 0;
+  }
+
   @media (prefers-reduced-motion: reduce) {
     animation: none;
   }


### PR DESCRIPTION
## 제목
refactor/low-cleanup

## 작업한 내용
- [x] tier-3 audit cleanup (unused helpers, useMemo, writeParsed, sections folder)
- [x] add segment loading.tsx for blog/news/recruit + detail pages

## 전달할 추가 이슈
- 없음

Closes #314