### PR TITLE
fix/pr-318-review

### DIFF
--- a/src/app/(i18n)/about/page.tsx
+++ b/src/app/(i18n)/about/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import type { HistorySchema } from "src/entities/about/history/schema/history.schema";
+import { resolveLocale } from "src/shared/libs/locale";
 import History from "src/widgets/about/history";
 import Introduce from "src/widgets/about/introduce";
 import Team from "src/widgets/about/team";
@@ -24,8 +25,7 @@ const About = async () => {
 	 * defaultLocale로 fallback되는 문제가 있음.
 	 */
 	const store = await cookies();
-	const localeValue = store.get("NEXT_LOCALE")?.value?.toLowerCase();
-	const locale = localeValue?.startsWith("en") ? "en" : "ko";
+	const locale = resolveLocale(store.get("NEXT_LOCALE")?.value);
 
 	let aboutHistory: unknown = {};
 	try {

--- a/src/app/(i18n)/blog/[idx]/client.tsx
+++ b/src/app/(i18n)/blog/[idx]/client.tsx
@@ -10,6 +10,7 @@ const ReactMarkdown = dynamic(() => import("react-markdown"), { ssr: false });
 
 import { useBlogViewMutation } from "src/features/blog/mutation/blog.mutation";
 import { useBlogDetailQuery } from "src/features/blog/query/blog.query";
+import { isKorean } from "src/shared/libs/locale";
 import { formatDate } from "src/shared/libs/ui/date";
 import BackLink from "src/shared/ui/back-link";
 import ImageThumb from "src/shared/ui/image-thumb";
@@ -64,8 +65,9 @@ const BlogDetailClient = ({ idx }: Props) => {
 	 */
 	if (!data) notFound();
 
-	const title = locale.startsWith("ko") ? data.titleKr : data.titleEn;
-	const content = locale.startsWith("ko") ? data.contentKr : data.contentEn;
+	const isKo = isKorean(locale);
+	const title = isKo ? data.titleKr : data.titleEn;
+	const content = isKo ? data.contentKr : data.contentEn;
 	const time = formatDate(data.createdAt, locale);
 
 	return (

--- a/src/app/(i18n)/blog/[idx]/page.tsx
+++ b/src/app/(i18n)/blog/[idx]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import { getBlogDetailApi } from "src/entities/blog/api/blog.api";
 import { blogQueries } from "src/features/blog/query/blog.query";
 import { createServerQueryClient } from "src/shared/libs/api/query/server-query-client";
+import { resolveLocale } from "src/shared/libs/locale";
 import BlogDetailClient from "./client";
 
 type PageProps = {
@@ -20,7 +21,7 @@ export const generateMetadata = async ({ params }: PageProps): Promise<Metadata>
 	try {
 		const blog = await getBlogDetailApi(idNum);
 		const store = await cookies();
-		const locale = store.get("NEXT_LOCALE")?.value === "en" ? "en" : "ko";
+		const locale = resolveLocale(store.get("NEXT_LOCALE")?.value);
 
 		const title = locale === "en" ? blog.titleEn : blog.titleKr;
 		const description = (locale === "en" ? blog.summaryEn : blog.summaryKr) ?? undefined;

--- a/src/app/(i18n)/layout.tsx
+++ b/src/app/(i18n)/layout.tsx
@@ -1,14 +1,14 @@
 import { cookies } from "next/headers";
 import { NextIntlClientProvider } from "next-intl";
 import type { ReactNode } from "react";
+import { resolveLocale } from "src/shared/libs/locale";
 import Footer from "src/shared/ui/footer";
 import Header from "src/shared/ui/header";
 import PageTransition from "src/shared/ui/page-transition";
 import styles from "./layout.module.scss";
 
 export default async function LocaleLayout({ children }: { children: ReactNode }) {
-	const localeValue = (await cookies()).get("NEXT_LOCALE")?.value?.toLowerCase();
-	const locale = localeValue?.startsWith("en") ? "en" : "ko"; // 기본 ko, 'en-US' 등 region code도 인식
+	const locale = resolveLocale((await cookies()).get("NEXT_LOCALE")?.value);
 	const messages = (await import(`../../../messages/${locale}.json`)).default;
 
 	return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { NextIntlClientProvider } from "next-intl";
 import { Suspense } from "react";
+import { resolveLocale } from "src/shared/libs/locale";
 import RouteLoading from "src/shared/ui/route-loading";
 import Providers from "src/widgets/layout/provider";
 
@@ -16,8 +17,7 @@ export const dynamic = "force-dynamic";
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
 	const store = await cookies();
-	const value = store.get("NEXT_LOCALE")?.value?.toLowerCase();
-	const locale = (value?.startsWith("en") ? "en" : "ko") as "en" | "ko";
+	const locale = resolveLocale(store.get("NEXT_LOCALE")?.value);
 
 	/**
 	 * 쿠키 기반으로 직접 messages 로드. (i18n) layout과 동일한 로직.

--- a/src/shared/libs/api/zod/index.ts
+++ b/src/shared/libs/api/zod/index.ts
@@ -6,17 +6,30 @@ type WriteMethod = "post" | "put" | "patch" | "delete";
 
 /**
  * @description
- * 204 No Content 응답 시 빈 응답 객체 반환
+ * 204 No Content / 빈 응답 처리.
+ * 스키마 형태가 다양하므로 null → undefined → 빈 객체 → envelope 순으로
+ * safeParse를 시도하고, 모두 실패하면 schema.parse(data)에서 명확한 ZodError를 던지도록 위임한다.
  */
 const handleNoContent = <S extends z.ZodTypeAny>(
 	status: number,
 	data: unknown,
 	schema: S,
 ): z.infer<S> => {
-	if (status === 204 || data === "" || data === null || data === undefined) {
-		return schema.parse({ status: 204, message: "No Content", data: null });
+	const isEmpty = status === 204 || data === "" || data === null || data === undefined;
+	if (!isEmpty) return schema.parse(data);
+
+	const candidates: unknown[] = [
+		null,
+		undefined,
+		{},
+		{ status: 204, message: "No Content", data: null },
+	];
+	for (const candidate of candidates) {
+		const result = schema.safeParse(candidate);
+		if (result.success) return result.data;
 	}
-	return schema.parse(data);
+	/* 어떤 후보도 통과하지 못하면 호출부가 ZodError를 받도록 강제 파싱. */
+	return schema.parse(data ?? null);
 };
 
 /**

--- a/src/shared/libs/api/zod/index.ts
+++ b/src/shared/libs/api/zod/index.ts
@@ -28,8 +28,8 @@ const handleNoContent = <S extends z.ZodTypeAny>(
 		const result = schema.safeParse(candidate);
 		if (result.success) return result.data;
 	}
-	/* 어떤 후보도 통과하지 못하면 호출부가 ZodError를 받도록 강제 파싱. */
-	return schema.parse(data ?? null);
+	/* 어떤 후보도 통과하지 못하면 원본 data 그대로 파싱 — 정확한 ZodError(received undefined 등)를 보존. */
+	return schema.parse(data);
 };
 
 /**

--- a/src/shared/libs/locale/index.ts
+++ b/src/shared/libs/locale/index.ts
@@ -1,0 +1,22 @@
+export type Locale = "ko" | "en";
+
+const DEFAULT_LOCALE: Locale = "ko";
+
+/**
+ * @description
+ * 입력 문자열을 지원 로케일(ko/en)로 정규화한다.
+ * "en-US", "EN", "english" 등 region code/대소문자 변형을 모두 흡수.
+ * 인식 불가 시 기본값(ko) 반환.
+ *
+ * @example
+ * resolveLocale("en-US") // "en"
+ * resolveLocale("ko-KR") // "ko"
+ * resolveLocale(undefined) // "ko"
+ */
+export const resolveLocale = (value?: string | null): Locale => {
+	if (!value) return DEFAULT_LOCALE;
+	return value.toLowerCase().startsWith("en") ? "en" : "ko";
+};
+
+/** 입력이 한국어 로케일인지 판별. */
+export const isKorean = (value?: string | null): boolean => resolveLocale(value) === "ko";

--- a/src/shared/libs/ui/date/index.ts
+++ b/src/shared/libs/ui/date/index.ts
@@ -1,3 +1,21 @@
+import { resolveLocale } from "src/shared/libs/locale";
+
+/* Intl.DateTimeFormat 인스턴스 캐시 — 매 호출마다 생성 비용 회피. 목록 페이지처럼 다수 호출 시 효과. */
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+const getFormatter = (locale: string) => {
+	const cached = formatterCache.get(locale);
+	if (cached) return cached;
+	const formatter = new Intl.DateTimeFormat(locale, {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+		timeZone: "Asia/Seoul",
+	});
+	formatterCache.set(locale, formatter);
+	return formatter;
+};
+
 /**
  * @description ISO 날짜 문자열을 로케일별 실제 날짜 표기로 변환한다.
  *
@@ -10,7 +28,7 @@
  * 입력에 다른 날짜가 나오는 일을 막는다. 미명시 시 시스템 시간대 사용.
  *
  * @param dateStr - ISO 8601 날짜 문자열
- * @param locale - 로케일 ("ko" 또는 "en")
+ * @param locale - 로케일 ("ko" 또는 "en", region code 허용)
  * @returns 로케일에 맞는 날짜 문자열 (입력 누락 시 빈 문자열)
  *
  * @example
@@ -21,10 +39,5 @@ export const formatDate = (dateStr?: string, locale?: string) => {
 	if (!dateStr || !locale) return "";
 	const date = new Date(dateStr);
 	if (Number.isNaN(date.getTime())) return "";
-	return new Intl.DateTimeFormat(locale.startsWith("ko") ? "ko" : "en", {
-		year: "numeric",
-		month: "short",
-		day: "numeric",
-		timeZone: "Asia/Seoul",
-	}).format(date);
+	return getFormatter(resolveLocale(locale)).format(date);
 };

--- a/src/widgets/blog/card/index.tsx
+++ b/src/widgets/blog/card/index.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import type { BlogItem } from "src/entities/blog/schema/blog.schema";
+import { isKorean } from "src/shared/libs/locale";
 import { formatDate } from "src/shared/libs/ui/date";
 import { ellipsis } from "src/shared/libs/ui/text";
 import ImageThumb from "src/shared/ui/image-thumb";
@@ -36,7 +37,7 @@ const stripMarkdown = (value: string) =>
 const BlogCard = ({ item, locale, href, priority = false }: Props) => {
 	const { idx, titleKr, titleEn, contentKr, contentEn, imageUrl, createdAt, views } = item;
 
-	const isKo = locale.startsWith("ko");
+	const isKo = isKorean(locale);
 	const title = (isKo ? titleKr : titleEn) ?? "";
 	const content = (isKo ? contentKr : contentEn) ?? "";
 	const plainContent = stripMarkdown(content);


### PR DESCRIPTION
## 제목
fix/pr-318-review

## 작업한 내용
- [x] add shared resolveLocale/isKorean util in src/shared/libs/locale
- [x] cache Intl.DateTimeFormat per locale
- [x] safer handleNoContent for 204 across diverse schema shapes

## 전달할 추가 이슈
- 없음

Closes #319