### PR TITLE
fix/main-perf-audit

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -78,8 +78,9 @@ const nextConfig = {
 				],
 			},
 			{
+				/* UUID 파일명은 불변 — 1년 immutable. 변경 시 새 UUID 발급해 cache-bust. */
 				source: "/media/:path*",
-				headers: [{ key: "Cache-Control", value: "public, max-age=604800" }],
+				headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
 			},
 		];
 	},

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,10 +1,25 @@
 import * as Sentry from "@sentry/nextjs";
 
+/**
+ * Sentry 클라이언트 초기화.
+ * replayIntegration (~70KB) 은 lazyLoadIntegration 으로 분리 — 초기 번들에서 제외,
+ * production 진입 후 CDN에서 비동기 fetch 해 addIntegration.
+ */
 Sentry.init({
 	dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 	tracesSampleRate: 0.1,
 	replaysSessionSampleRate: 0,
 	replaysOnErrorSampleRate: 1.0,
-	integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
+	integrations: [Sentry.browserTracingIntegration()],
 	enabled: process.env.NODE_ENV === "production",
 });
+
+if (process.env.NODE_ENV === "production" && typeof window !== "undefined") {
+	Sentry.lazyLoadIntegration("replayIntegration")
+		.then((replayIntegration) => {
+			Sentry.addIntegration(replayIntegration());
+		})
+		.catch(() => {
+			/* CDN fetch 실패 시 replay 없이 진행 — tracing 은 여전히 동작. */
+		});
+}

--- a/src/app/(i18n)/page.tsx
+++ b/src/app/(i18n)/page.tsx
@@ -1,8 +1,12 @@
+import dynamic from "next/dynamic";
 import Banner from "src/widgets/main/banner";
-import Collaborations from "src/widgets/main/collaborations";
 import Problem from "src/widgets/main/problem";
-import Solution from "src/widgets/main/solution/section";
 import styles from "./style.module.scss";
+
+/* below-fold 위젯은 dynamic import — initial JS payload 절감.
+   Solution 은 modal/GSAP, Collaborations 는 로고 그리드. 둘 다 즉시 필요 없음. */
+const Solution = dynamic(() => import("src/widgets/main/solution/section"));
+const Collaborations = dynamic(() => import("src/widgets/main/collaborations"));
 
 const MainPage = () => {
 	return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 	description: "Bigtablet's Official Website",
 };
 
-export const dynamic = "force-dynamic";
+/* force-dynamic 제거 — cookies() 사용으로 next 가 자동 dynamic 처리. 명시 force는 정적 최적화 차단해 불필요. */
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
 	const store = await cookies();

--- a/src/widgets/main/banner/index.tsx
+++ b/src/widgets/main/banner/index.tsx
@@ -2,32 +2,63 @@
 
 import { Button } from "@bigtablet/design-system";
 import { ChevronDown } from "lucide-react";
+import Image from "next/image";
 import { useTranslations } from "next-intl";
+import { useEffect, useRef, useState } from "react";
 import styles from "./style.module.scss";
+
+const VIDEO_SRC = "/media/6122c823-e40e-4d29-8855-4a64f0c7d881";
+const POSTER_SRC = "/images/banner-poster.webp";
 
 /**
  * @component Banner
  *
  * @description
- * 메인 페이지 상단 히어로 배너 섹션.
- * CSS keyframe 애니메이션으로 텍스트 등장 (GSAP 의존성 제거).
- * prefers-reduced-motion 자동 대응 (CSS media query).
+ * 메인 페이지 상단 히어로 배너.
+ * LCP 최적화 — 포스터를 next/image priority 로 즉시 렌더, 동영상은 hydration 이후 idle 시점에 src 부여.
+ * 동영상 file fetch 가 LCP/페이로드를 막지 않도록 deferred load 전략.
  */
 const Banner = () => {
 	const t = useTranslations("main.banner");
+	const videoRef = useRef<HTMLVideoElement | null>(null);
+	const [shouldLoadVideo, setShouldLoadVideo] = useState(false);
+
+	useEffect(() => {
+		/* hydration 이후 idle 시점에 비디오 fetch 시작. requestIdleCallback 미지원 환경은 setTimeout fallback. */
+		const ric = (window as Window & { requestIdleCallback?: (cb: () => void) => number })
+			.requestIdleCallback;
+		const schedule = ric ?? ((cb: () => void) => setTimeout(cb, 500));
+		const id = schedule(() => setShouldLoadVideo(true));
+		return () => {
+			const cic = (window as Window & { cancelIdleCallback?: (id: number) => void })
+				.cancelIdleCallback;
+			if (cic && typeof id === "number") cic(id);
+		};
+	}, []);
 
 	return (
 		<section className={styles.banner} aria-labelledby="banner_title">
 			<div className={styles.banner_video}>
+				{/* poster — LCP candidate, next/image priority 로 즉시 렌더 */}
+				<Image
+					src={POSTER_SRC}
+					alt=""
+					fill
+					priority
+					sizes="100vw"
+					className={styles.banner_poster}
+				/>
 				<video
+					ref={videoRef}
 					className={styles.banner_video_tag}
-					src="/media/6122c823-e40e-4d29-8855-4a64f0c7d881"
-					poster="/images/banner-poster.webp"
+					poster={POSTER_SRC}
 					autoPlay
 					loop
 					muted
 					playsInline
-					preload="metadata"
+					preload="none"
+					/* 일정 시점 이후에만 src 부여 — 그 전엔 비디오 fetch 안 일어남 */
+					{...(shouldLoadVideo ? { src: VIDEO_SRC } : {})}
 				/>
 				<div className={styles.banner_overlay} />
 			</div>

--- a/src/widgets/main/banner/index.tsx
+++ b/src/widgets/main/banner/index.tsx
@@ -4,11 +4,12 @@ import { Button } from "@bigtablet/design-system";
 import { ChevronDown } from "lucide-react";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import styles from "./style.module.scss";
 
 const VIDEO_SRC = "/media/6122c823-e40e-4d29-8855-4a64f0c7d881";
 const POSTER_SRC = "/images/banner-poster.webp";
+const VIDEO_DEFER_FALLBACK_MS = 500;
 
 /**
  * @component Banner
@@ -20,20 +21,21 @@ const POSTER_SRC = "/images/banner-poster.webp";
  */
 const Banner = () => {
 	const t = useTranslations("main.banner");
-	const videoRef = useRef<HTMLVideoElement | null>(null);
 	const [shouldLoadVideo, setShouldLoadVideo] = useState(false);
 
 	useEffect(() => {
 		/* hydration 이후 idle 시점에 비디오 fetch 시작. requestIdleCallback 미지원 환경은 setTimeout fallback. */
 		const ric = (window as Window & { requestIdleCallback?: (cb: () => void) => number })
 			.requestIdleCallback;
-		const schedule = ric ?? ((cb: () => void) => setTimeout(cb, 500));
-		const id = schedule(() => setShouldLoadVideo(true));
-		return () => {
-			const cic = (window as Window & { cancelIdleCallback?: (id: number) => void })
-				.cancelIdleCallback;
-			if (cic && typeof id === "number") cic(id);
-		};
+		const cic = (window as Window & { cancelIdleCallback?: (id: number) => void })
+			.cancelIdleCallback;
+
+		if (ric && cic) {
+			const id = ric(() => setShouldLoadVideo(true));
+			return () => cic(id);
+		}
+		const timer = setTimeout(() => setShouldLoadVideo(true), VIDEO_DEFER_FALLBACK_MS);
+		return () => clearTimeout(timer);
 	}, []);
 
 	return (
@@ -49,7 +51,6 @@ const Banner = () => {
 					className={styles.banner_poster}
 				/>
 				<video
-					ref={videoRef}
 					className={styles.banner_video_tag}
 					poster={POSTER_SRC}
 					autoPlay

--- a/src/widgets/main/banner/style.module.scss
+++ b/src/widgets/main/banner/style.module.scss
@@ -17,10 +17,19 @@
 	height: 100%;
 }
 
+/* next/image fill 컨테이너 — 포스터가 LCP 후보로 즉시 paint. 비디오 위에 deferred load. */
+.banner_poster {
+	object-fit: cover;
+	z-index: 0;
+}
+
 .banner_video_tag {
+	position: absolute;
+	inset: 0;
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
+	z-index: 1;
 }
 
 .banner_overlay {

--- a/src/widgets/main/problem/index.tsx
+++ b/src/widgets/main/problem/index.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { useTranslations } from "next-intl";
+import { useEffect, useRef, useState } from "react";
 import styles from "./style.module.scss";
 
 /**
@@ -6,14 +9,39 @@ import styles from "./style.module.scss";
  *
  * @description
  * 메인 페이지 문제 제기 섹션.
- * 스크롤 시 등장 애니메이션은 IntersectionObserver + CSS keyframe 로 처리하던 GSAP
- * scroll-reveal 을 대체 — 메인 페이지 초기 번들에서 GSAP 의존성 제거.
+ * IntersectionObserver 로 뷰포트 진입 감지 → is_visible 클래스 부여 → CSS 애니메이션 트리거.
+ * GSAP scroll-reveal 의 가벼운 대체 — 라이브러리 의존성 없음, 초기 번들에 GSAP 포함 안 됨.
  */
 const Problem = () => {
 	const t = useTranslations("main.problem");
+	const sectionRef = useRef<HTMLElement | null>(null);
+	const [visible, setVisible] = useState(false);
+
+	useEffect(() => {
+		const node = sectionRef.current;
+		if (!node) return;
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting) {
+						setVisible(true);
+						observer.disconnect();
+						break;
+					}
+				}
+			},
+			{ threshold: 0.15 },
+		);
+		observer.observe(node);
+		return () => observer.disconnect();
+	}, []);
 
 	return (
-		<section className={styles.problem} aria-labelledby="problem_title">
+		<section
+			ref={sectionRef}
+			className={`${styles.problem} ${visible ? styles.is_visible : ""}`}
+			aria-labelledby="problem_title"
+		>
 			<h2 id="problem_title" className={styles.problem_title}>
 				{t("title")}
 			</h2>

--- a/src/widgets/main/problem/index.tsx
+++ b/src/widgets/main/problem/index.tsx
@@ -1,7 +1,4 @@
-"use client";
-
 import { useTranslations } from "next-intl";
-import { useScrollReveal } from "src/shared/hooks/use-scroll-reveal";
 import styles from "./style.module.scss";
 
 /**
@@ -9,19 +6,14 @@ import styles from "./style.module.scss";
  *
  * @description
  * 메인 페이지 문제 제기 섹션.
- * 스크롤 시 fade-up 애니메이션으로 등장한다.
- *
- * @see {@link useScrollReveal} 스크롤 애니메이션 훅
+ * 스크롤 시 등장 애니메이션은 IntersectionObserver + CSS keyframe 로 처리하던 GSAP
+ * scroll-reveal 을 대체 — 메인 페이지 초기 번들에서 GSAP 의존성 제거.
  */
 const Problem = () => {
 	const t = useTranslations("main.problem");
-	const sectionRef = useScrollReveal<HTMLElement>(
-		`.${styles.problem_title}, .${styles.problem_description}`,
-		{ variant: "fade-up", stagger: 0.2 },
-	);
 
 	return (
-		<section ref={sectionRef} className={styles.problem} aria-labelledby="problem_title">
+		<section className={styles.problem} aria-labelledby="problem_title">
 			<h2 id="problem_title" className={styles.problem_title}>
 				{t("title")}
 			</h2>

--- a/src/widgets/main/problem/style.module.scss
+++ b/src/widgets/main/problem/style.module.scss
@@ -11,6 +11,34 @@
   color: token.$text_normal;
 }
 
+/* CSS animation으로 fade-up — GSAP scroll-reveal 대체. 페이지 로드 즉시 시작. */
+.problem_title,
+.problem_description {
+  animation: problem_fade_up 0.7s ease-out both;
+}
+
+.problem_description {
+  animation-delay: 0.15s;
+}
+
+@keyframes problem_fade_up {
+  from {
+    opacity: 0;
+    transform: translateY(40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .problem_title,
+  .problem_description {
+    animation: none;
+  }
+}
+
 .problem_title {
   @include token.heading_2;
   flex: 0 0 35%;

--- a/src/widgets/main/problem/style.module.scss
+++ b/src/widgets/main/problem/style.module.scss
@@ -11,31 +11,31 @@
   color: token.$text_normal;
 }
 
-/* CSS animation으로 fade-up — GSAP scroll-reveal 대체. 페이지 로드 즉시 시작. */
+/* 기본은 invisible — IntersectionObserver 가 is_visible 부여하면 fade-up 시작.
+   below-fold 섹션이라 스크롤로 진입한 순간 reveal 효과 유지. */
 .problem_title,
 .problem_description {
-  animation: problem_fade_up 0.7s ease-out both;
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity 0.7s ease-out, transform 0.7s ease-out;
 }
 
-.problem_description {
-  animation-delay: 0.15s;
+.is_visible .problem_title,
+.is_visible .problem_description {
+  opacity: 1;
+  transform: translateY(0);
 }
 
-@keyframes problem_fade_up {
-  from {
-    opacity: 0;
-    transform: translateY(40px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+.is_visible .problem_description {
+  transition-delay: 0.15s;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .problem_title,
   .problem_description {
-    animation: none;
+    opacity: 1;
+    transform: none;
+    transition: none;
   }
 }
 


### PR DESCRIPTION
## 제목
fix/main-perf-audit

## 작업한 내용
- [x] Banner video deferred load (LCP 후 idle 시점)
- [x] Banner poster를 next/image priority로 LCP element 화
- [x] Problem 위젯 GSAP scroll-reveal → CSS 애니메이션 (메인 / 라우트에서 GSAP 제거)
- [x] 메인 페이지 below-fold 위젯 dynamic import (Solution, Collaborations)
- [x] /media 캐시 7d → 1y immutable

예상 효과: LCP 4.5s → 1.5-2s, 초기 payload 19MB → 수백KB, JS 200KB 절감

## 전달할 추가 이슈
- 없음

Closes #347