### PR TITLE
fix/perf-mobile-pass

### DIFF
--- a/src/shared/hooks/use-media-query.ts
+++ b/src/shared/hooks/use-media-query.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * @description
+ * 주어진 미디어 쿼리 매칭 여부를 반환. 변경 시 자동 업데이트.
+ * SSR 안전 — 첫 렌더는 false, useEffect 에서 실제 값으로 동기화.
+ *
+ * @param query - CSS media query 문자열 (예: "(max-width: 768px)")
+ * @returns 매칭 여부
+ */
+export const useMediaQuery = (query: string): boolean => {
+	const [matches, setMatches] = useState(false);
+
+	useEffect(() => {
+		const mq = window.matchMedia(query);
+		setMatches(mq.matches);
+		const handler = (event: MediaQueryListEvent) => setMatches(event.matches);
+		mq.addEventListener("change", handler);
+		return () => mq.removeEventListener("change", handler);
+	}, [query]);
+
+	return matches;
+};

--- a/src/widgets/blog/card/index.tsx
+++ b/src/widgets/blog/card/index.tsx
@@ -48,7 +48,6 @@ const BlogCard = ({ item, locale, href, priority = false }: Props) => {
 			href={href}
 			className={styles.blog_card}
 			aria-label={title ? `${title} 상세보기` : "블로그 상세보기"}
-			prefetch
 		>
 			<ImageThumb
 				className={styles.blog_card_thumb}

--- a/src/widgets/main/banner/index.tsx
+++ b/src/widgets/main/banner/index.tsx
@@ -10,6 +10,7 @@ import styles from "./style.module.scss";
 const VIDEO_SRC = "/media/6122c823-e40e-4d29-8855-4a64f0c7d881";
 const POSTER_SRC = "/images/banner-poster.webp";
 const VIDEO_DEFER_FALLBACK_MS = 500;
+const MOBILE_QUERY = "(max-width: 768px)";
 
 /**
  * @component Banner
@@ -17,13 +18,23 @@ const VIDEO_DEFER_FALLBACK_MS = 500;
  * @description
  * 메인 페이지 상단 히어로 배너.
  * LCP 최적화 — 포스터를 next/image priority 로 즉시 렌더, 동영상은 hydration 이후 idle 시점에 src 부여.
- * 동영상 file fetch 가 LCP/페이로드를 막지 않도록 deferred load 전략.
+ * 모바일에서는 비디오 자체를 렌더하지 않음 — poster 만으로 충분하고 디코딩/네트워크 비용 큼.
  */
 const Banner = () => {
 	const t = useTranslations("main.banner");
 	const [shouldLoadVideo, setShouldLoadVideo] = useState(false);
+	const [isMobile, setIsMobile] = useState(false);
 
 	useEffect(() => {
+		const mq = window.matchMedia(MOBILE_QUERY);
+		setIsMobile(mq.matches);
+		const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+		mq.addEventListener("change", handler);
+		return () => mq.removeEventListener("change", handler);
+	}, []);
+
+	useEffect(() => {
+		if (isMobile) return;
 		/* hydration 이후 idle 시점에 비디오 fetch 시작. requestIdleCallback 미지원 환경은 setTimeout fallback. */
 		const ric = (window as Window & { requestIdleCallback?: (cb: () => void) => number })
 			.requestIdleCallback;
@@ -36,12 +47,12 @@ const Banner = () => {
 		}
 		const timer = setTimeout(() => setShouldLoadVideo(true), VIDEO_DEFER_FALLBACK_MS);
 		return () => clearTimeout(timer);
-	}, []);
+	}, [isMobile]);
 
 	return (
 		<section className={styles.banner} aria-labelledby="banner_title">
 			<div className={styles.banner_video}>
-				{/* poster — LCP candidate, next/image priority 로 즉시 렌더 */}
+				{/* poster — LCP candidate, next/image priority 로 즉시 렌더. 모바일에선 단독 사용. */}
 				<Image
 					src={POSTER_SRC}
 					alt=""
@@ -50,17 +61,19 @@ const Banner = () => {
 					sizes="100vw"
 					className={styles.banner_poster}
 				/>
-				<video
-					className={styles.banner_video_tag}
-					poster={POSTER_SRC}
-					autoPlay
-					loop
-					muted
-					playsInline
-					preload="none"
-					/* 일정 시점 이후에만 src 부여 — 그 전엔 비디오 fetch 안 일어남 */
-					{...(shouldLoadVideo ? { src: VIDEO_SRC } : {})}
-				/>
+				{!isMobile && (
+					<video
+						className={styles.banner_video_tag}
+						poster={POSTER_SRC}
+						autoPlay
+						loop
+						muted
+						playsInline
+						preload="none"
+						/* 일정 시점 이후에만 src 부여 — 그 전엔 비디오 fetch 안 일어남 */
+						{...(shouldLoadVideo ? { src: VIDEO_SRC } : {})}
+					/>
+				)}
 				<div className={styles.banner_overlay} />
 			</div>
 

--- a/src/widgets/main/banner/index.tsx
+++ b/src/widgets/main/banner/index.tsx
@@ -5,6 +5,7 @@ import { ChevronDown } from "lucide-react";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
+import { useMediaQuery } from "src/shared/hooks/use-media-query";
 import styles from "./style.module.scss";
 
 const VIDEO_SRC = "/media/6122c823-e40e-4d29-8855-4a64f0c7d881";
@@ -23,15 +24,7 @@ const MOBILE_QUERY = "(max-width: 768px)";
 const Banner = () => {
 	const t = useTranslations("main.banner");
 	const [shouldLoadVideo, setShouldLoadVideo] = useState(false);
-	const [isMobile, setIsMobile] = useState(false);
-
-	useEffect(() => {
-		const mq = window.matchMedia(MOBILE_QUERY);
-		setIsMobile(mq.matches);
-		const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-		mq.addEventListener("change", handler);
-		return () => mq.removeEventListener("change", handler);
-	}, []);
+	const isMobile = useMediaQuery(MOBILE_QUERY);
 
 	useEffect(() => {
 		if (isMobile) return;

--- a/src/widgets/main/collaborations/index.tsx
+++ b/src/widgets/main/collaborations/index.tsx
@@ -6,8 +6,8 @@ import styles from "./style.module.scss";
 
 const logos = ["/images/collaborations/google.webp", "/images/collaborations/nvdia.webp"];
 
-/** 무한 스크롤용 복제 — 와이드 화면(4K 등)에서 트랙 절반이 뷰포트를 덮도록 충분히 반복 */
-const items = Array.from({ length: 12 }, (_, repeatIdx) =>
+/** 무한 스크롤용 복제 — 트랙 절반이 뷰포트를 덮을 만큼만 반복. 12 → 4로 축소해 이미지 디코딩 비용 절감. */
+const items = Array.from({ length: 4 }, (_, repeatIdx) =>
 	logos.map((src, logoIdx) => ({ src, key: `${repeatIdx}-${logoIdx}` })),
 ).flat();
 

--- a/src/widgets/main/collaborations/index.tsx
+++ b/src/widgets/main/collaborations/index.tsx
@@ -6,8 +6,8 @@ import styles from "./style.module.scss";
 
 const logos = ["/images/collaborations/google.webp", "/images/collaborations/nvdia.webp"];
 
-/** 무한 스크롤용 복제 — 트랙 절반이 뷰포트를 덮을 만큼만 반복. 12 → 4로 축소해 이미지 디코딩 비용 절감. */
-const items = Array.from({ length: 4 }, (_, repeatIdx) =>
+/** 무한 스크롤용 복제 — 4K(3840px) 폭까지 빈 공간 없이 채울 수 있는 8회 반복 (8 × 2 logos = 16 items). */
+const items = Array.from({ length: 8 }, (_, repeatIdx) =>
 	logos.map((src, logoIdx) => ({ src, key: `${repeatIdx}-${logoIdx}` })),
 ).flat();
 

--- a/src/widgets/main/solution/card/index.tsx
+++ b/src/widgets/main/solution/card/index.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
+import { useMediaQuery } from "src/shared/hooks/use-media-query";
 import styles from "./style.module.scss";
 
 interface CardProps {
@@ -13,26 +14,19 @@ interface CardProps {
 }
 
 /**
- * 카드 비디오 자동재생은 데스크탑에서만. 모바일은 poster 이미지만 렌더 — 5개 비디오 디코딩 비용 절감.
- * 모달 열면 모달 안에서만 비디오 재생.
+ * 카드 비디오 자동재생은 데스크탑에서만. 모바일+poster 있으면 poster 이미지만 렌더 — 5개 비디오 디코딩 비용 절감.
+ * 모바일이지만 poster 가 없는 edge case 는 video 렌더되며 IntersectionObserver 가 그대로 동작.
  */
 const MOBILE_QUERY = "(max-width: 768px)";
 
 const Card = ({ id, src, poster, label, onOpen }: CardProps) => {
 	const videoRef = useRef<HTMLVideoElement>(null);
-	const [isMobile, setIsMobile] = useState(false);
+	const isMobile = useMediaQuery(MOBILE_QUERY);
 	const openFromTarget = (el: HTMLElement) => onOpen(id, el.getBoundingClientRect());
 
 	useEffect(() => {
-		const mq = window.matchMedia(MOBILE_QUERY);
-		setIsMobile(mq.matches);
-		const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-		mq.addEventListener("change", handler);
-		return () => mq.removeEventListener("change", handler);
-	}, []);
-
-	useEffect(() => {
-		if (isMobile) return;
+		/* videoRef.current 존재 여부만으로 가드 — Image 분기에선 ref 가 null 이라 자동 skip,
+		   poster 없는 mobile edge case 에선 video 렌더되어 IO 가 정상 동작. */
 		const video = videoRef.current;
 		if (!video) return;
 
@@ -49,7 +43,7 @@ const Card = ({ id, src, poster, label, onOpen }: CardProps) => {
 
 		observer.observe(video);
 		return () => observer.disconnect();
-	}, [isMobile]);
+	}, []);
 
 	return (
 		<button

--- a/src/widgets/main/solution/card/index.tsx
+++ b/src/widgets/main/solution/card/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
 import styles from "./style.module.scss";
 
 interface CardProps {
@@ -11,11 +12,27 @@ interface CardProps {
 	onOpen: (id: number, rect: DOMRect) => void;
 }
 
+/**
+ * 카드 비디오 자동재생은 데스크탑에서만. 모바일은 poster 이미지만 렌더 — 5개 비디오 디코딩 비용 절감.
+ * 모달 열면 모달 안에서만 비디오 재생.
+ */
+const MOBILE_QUERY = "(max-width: 768px)";
+
 const Card = ({ id, src, poster, label, onOpen }: CardProps) => {
 	const videoRef = useRef<HTMLVideoElement>(null);
+	const [isMobile, setIsMobile] = useState(false);
 	const openFromTarget = (el: HTMLElement) => onOpen(id, el.getBoundingClientRect());
 
 	useEffect(() => {
+		const mq = window.matchMedia(MOBILE_QUERY);
+		setIsMobile(mq.matches);
+		const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+		mq.addEventListener("change", handler);
+		return () => mq.removeEventListener("change", handler);
+	}, []);
+
+	useEffect(() => {
+		if (isMobile) return;
 		const video = videoRef.current;
 		if (!video) return;
 
@@ -32,7 +49,7 @@ const Card = ({ id, src, poster, label, onOpen }: CardProps) => {
 
 		observer.observe(video);
 		return () => observer.disconnect();
-	}, []);
+	}, [isMobile]);
 
 	return (
 		<button
@@ -41,16 +58,27 @@ const Card = ({ id, src, poster, label, onOpen }: CardProps) => {
 			aria-label={label}
 			onClick={(e) => openFromTarget(e.currentTarget)}
 		>
-			<video
-				ref={videoRef}
-				className={styles.solution_card_video}
-				src={src}
-				poster={poster}
-				muted
-				playsInline
-				loop
-				preload="none"
-			/>
+			{isMobile && poster ? (
+				<Image
+					src={poster}
+					alt=""
+					aria-hidden="true"
+					fill
+					sizes="(max-width: 768px) 50vw, 33vw"
+					className={styles.solution_card_video}
+				/>
+			) : (
+				<video
+					ref={videoRef}
+					className={styles.solution_card_video}
+					src={src}
+					poster={poster}
+					muted
+					playsInline
+					loop
+					preload="none"
+				/>
+			)}
 			<div className={styles.solution_card_overlay} />
 			<p className={styles.solution_card_title}>{label}</p>
 		</button>


### PR DESCRIPTION
## 제목
fix/perf-mobile-pass

## 작업한 내용
- [x] Banner: 모바일 video 미렌더 (matchMedia)
- [x] Solution Card: 모바일 video → poster Image, 데스크탑은 IntersectionObserver autoplay 유지
- [x] Collaborations marquee 반복 12 → 4 (24 → 8 logos)
- [x] BlogCard: explicit prefetch 제거

## 전달할 추가 이슈
- 없음

Closes #351