### PR TITLE
fix/banner-stacking-context

### DIFF
--- a/src/widgets/main/banner/style.module.scss
+++ b/src/widgets/main/banner/style.module.scss
@@ -15,12 +15,13 @@
 	inset: 0;
 	width: 100%;
 	height: 100%;
+	/* 자체 stacking context 생성 — 내부 layer(poster/video/overlay)들의 z-index가 외부로 bubble up 안 됨 */
+	isolation: isolate;
 }
 
-/* next/image fill 컨테이너 — 포스터가 LCP 후보로 즉시 paint. 비디오 위에 deferred load. */
+/* next/image fill — LCP 후보로 즉시 paint. DOM 순서 상 video 보다 먼저 → video 가 자연스럽게 그 위에 */
 .banner_poster {
 	object-fit: cover;
-	z-index: 0;
 }
 
 .banner_video_tag {
@@ -29,7 +30,6 @@
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
-	z-index: 1;
 }
 
 .banner_overlay {

--- a/src/widgets/main/banner/style.module.scss
+++ b/src/widgets/main/banner/style.module.scss
@@ -15,7 +15,7 @@
 	inset: 0;
 	width: 100%;
 	height: 100%;
-	/* 자체 stacking context 생성 — 내부 layer(poster/video/overlay)들의 z-index가 외부로 bubble up 안 됨 */
+	/* 자체 stacking context 생성 — 향후 내부 요소에 z-index가 추가되더라도 외부(banner_content 등)로 영향이 전파되는 것을 방지 */
 	isolation: isolate;
 }
 


### PR DESCRIPTION
## 제목
fix/banner-stacking-context

## 작업한 내용
- [x] `.banner_video` 에 `isolation: isolate` 추가 — 내부 z-index 가 외부로 bubble up 차단
- [x] `.banner_video_tag`, `.banner_poster` 의 명시 z-index 제거 (DOM 순서로 자연 정렬)

기존 디자인(title + description + CTA + scroll indicator) 즉시 복원.

## 전달할 추가 이슈
- 없음

Closes #353