### PR TITLE
config/lighthouse-api-mock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"042f9c48-fc84-48ac-a6f8-ae51a2d12fa8","pid":92973,"procStart":"Wed May 13 04:39:41 2026","acquiredAt":1778647461667}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"042f9c48-fc84-48ac-a6f8-ae51a2d12fa8","pid":92973,"procStart":"Wed May 13 04:39:41 2026","acquiredAt":1778647461667}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -23,7 +23,8 @@ jobs:
       matrix:
         preset: [mobile, desktop]
     env:
-      NEXT_PUBLIC_SERVER_URL: http://127.0.0.1:1
+      # 로컬 mock API 서버 — scripts/lighthouse-api-mock.mjs 가 4000번 포트에서 응답
+      NEXT_PUBLIC_SERVER_URL: http://127.0.0.1:4000
 
     steps:
       - name: Checkout
@@ -44,6 +45,21 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Start mock API server
+        # background — lighthouse 가 페이지 SSR/렌더할 때 fetch 응답
+        run: |
+          node scripts/lighthouse-api-mock.mjs &
+          echo $! > /tmp/mock-api.pid
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -fs http://127.0.0.1:4000/blog/list > /dev/null; then
+              echo "mock api ready"
+              exit 0
+            fi
+            sleep 0.5
+          done
+          echo "mock api failed to start" >&2
+          exit 1
+
       - name: Run Lighthouse CI (${{ matrix.preset }})
         id: lhci
         uses: treosh/lighthouse-ci-action@v12
@@ -52,6 +68,13 @@ jobs:
           uploadArtifacts: true
           temporaryPublicStorage: true
           artifactName: lighthouse-results-${{ matrix.preset }}
+
+      - name: Stop mock API server
+        if: always()
+        run: |
+          if [ -f /tmp/mock-api.pid ]; then
+            kill "$(cat /tmp/mock-api.pid)" 2>/dev/null || true
+          fi
 
       - name: Post Lighthouse report to PR
         # PR 컨텍스트에서만 코멘트. workflow_dispatch 는 context.issue.number 없음 → skip.

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ yarn.lock
 /blob-report/
 .lighthouseci/
 .lighthouseci-report/
+.claude/scheduled_tasks.lock

--- a/scripts/lighthouse-api-mock.mjs
+++ b/scripts/lighthouse-api-mock.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Lighthouse CI 전용 mock API 서버.
+ * CI 환경에서 실제 백엔드가 없으면 모든 데이터 의존 페이지가 ErrorFallback 으로 렌더되어
+ * 측정값이 실제 페이지 perf 를 반영 못 함. 이 서버는 src/test/msw/handlers.ts 와 동일한
+ * shape 의 응답을 반환해 SSR + client query 가 실제 콘텐츠로 통과하게 한다.
+ *
+ * Node 만 사용 — 외부 의존성 없음. 0.0.0.0:4000 listen.
+ */
+import { createServer } from "node:http";
+
+const PORT = Number(process.env.MOCK_PORT ?? 4000);
+
+const ok = (data) => ({ status: 200, message: "ok", data });
+
+const blogItem = {
+	idx: 1,
+	titleKr: "테스트 블로그",
+	titleEn: "Test Blog",
+	imageUrl: "https://storage.googleapis.com/bigtablet-homepage/mock-blog.webp",
+	summaryKr: "요약",
+	summaryEn: "summary",
+	contentKr: "내용",
+	contentEn: "content",
+	createdAt: "2026-01-01T00:00:00.000Z",
+	modifiedAt: "2026-01-02T00:00:00.000Z",
+	views: 10,
+};
+
+const newsItem = {
+	idx: 1,
+	titleKr: "테스트 뉴스",
+	titleEn: "Test News",
+	newsUrl: "https://example.com/news/1",
+	thumbnailImageUrl: "https://storage.googleapis.com/bigtablet-homepage/mock-news.webp",
+	createdAt: "2026-01-01T00:00:00.000Z",
+	modifiedAt: "2026-01-02T00:00:00.000Z",
+};
+
+const recruitItem = {
+	idx: 1,
+	title: "프론트엔드 개발자",
+	department: "IT",
+	location: "PANGYO",
+	recruitType: "FULL_TIME",
+	experiment: "",
+	education: "NO_REQUIREMENT",
+	companyIntroduction: "회사 소개",
+	positionIntroduction: "직무 소개",
+	mainResponsibility: "주요 업무",
+	qualification: "자격 요건",
+	preferredQualification: "우대 사항",
+	startDate: "2026-01-01",
+	endDate: null,
+	isActive: true,
+};
+
+const ROUTES = {
+	"GET /blog/list": () => ok([blogItem]),
+	"GET /blog": () => ok(blogItem),
+	"PATCH /blog": () => ok(null),
+	"GET /news/list": () => ok([newsItem]),
+	"GET /job/list": () => ok([recruitItem]),
+	"GET /job": () => ok(recruitItem),
+	"POST /recruit": () => ({ status: 201, message: "ok" }),
+	"POST /talent": () => ({ status: 201, message: "ok" }),
+	"POST /auth/email": () => ({ status: 200, message: "ok" }),
+	"POST /auth/email/check": () => ({ status: 200, message: "verified" }),
+	"POST /gcp": () => ok("https://storage.googleapis.com/mock-file.pdf"),
+};
+
+const server = createServer((req, res) => {
+	const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
+	const key = `${req.method} ${url.pathname}`;
+	const handler = ROUTES[key];
+
+	res.setHeader("Access-Control-Allow-Origin", "*");
+	res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+	res.setHeader("Access-Control-Allow-Methods", "GET, POST, PATCH, PUT, DELETE, OPTIONS");
+
+	if (req.method === "OPTIONS") {
+		res.statusCode = 204;
+		res.end();
+		return;
+	}
+
+	if (!handler) {
+		res.statusCode = 404;
+		res.setHeader("Content-Type", "application/json");
+		res.end(JSON.stringify({ status: 404, message: `no mock for ${key}` }));
+		return;
+	}
+
+	res.statusCode = 200;
+	res.setHeader("Content-Type", "application/json");
+	res.end(JSON.stringify(handler()));
+});
+
+server.listen(PORT, "0.0.0.0", () => {
+	console.log(`[lighthouse-api-mock] listening on http://127.0.0.1:${PORT}`);
+});
+
+const shutdown = (signal) => {
+	console.log(`[lighthouse-api-mock] received ${signal}, closing`);
+	server.close(() => process.exit(0));
+};
+process.on("SIGINT", () => shutdown("SIGINT"));
+process.on("SIGTERM", () => shutdown("SIGTERM"));

--- a/scripts/lighthouse-api-mock.mjs
+++ b/scripts/lighthouse-api-mock.mjs
@@ -66,11 +66,16 @@ const ROUTES = {
 	"POST /talent": () => ({ status: 201, message: "ok" }),
 	"POST /auth/email": () => ({ status: 200, message: "ok" }),
 	"POST /auth/email/check": () => ({ status: 200, message: "verified" }),
-	"POST /gcp": () => ok("https://storage.googleapis.com/mock-file.pdf"),
+	"POST /gcp": () => ({
+		status: 201,
+		message: "ok",
+		data: "https://storage.googleapis.com/mock-file.pdf",
+	}),
 };
 
 const server = createServer((req, res) => {
-	const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
+	/* Host 헤더 누락 케이스 — 고정 base 로 안전하게 pathname 만 파싱 */
+	const url = new URL(req.url ?? "/", "http://localhost");
 	const key = `${req.method} ${url.pathname}`;
 	const handler = ROUTES[key];
 
@@ -91,9 +96,11 @@ const server = createServer((req, res) => {
 		return;
 	}
 
-	res.statusCode = 200;
+	/* 응답 페이로드의 status 필드를 HTTP statusCode 로도 반영 — MSW handlers 와 일치 */
+	const result = handler();
+	res.statusCode = typeof result.status === "number" ? result.status : 200;
 	res.setHeader("Content-Type", "application/json");
-	res.end(JSON.stringify(handler()));
+	res.end(JSON.stringify(result));
 });
 
 server.listen(PORT, "0.0.0.0", () => {


### PR DESCRIPTION
## 제목
config/lighthouse-api-mock

## 작업한 내용
- [x] scripts/lighthouse-api-mock.mjs — 무의존성 node http 서버, MSW handlers 와 동일 shape 응답
- [x] workflow NEXT_PUBLIC_SERVER_URL=http://127.0.0.1:4000 + mock 서버 기동/종료 단계

mock 도입 전 데이터 페이지는 ErrorFallback 만 렌더되어 측정 부정확. 도입 후 실제 페이지 perf 측정 가능.

## 전달할 추가 이슈
- 없음

Closes #355