### PR TITLE
fix/perf-providers-sentry-cookie

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"042f9c48-fc84-48ac-a6f8-ae51a2d12fa8","pid":92973,"procStart":"Wed May 13 04:39:41 2026","acquiredAt":1778647461667}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"042f9c48-fc84-48ac-a6f8-ae51a2d12fa8","pid":92973,"procStart":"Wed May 13 04:39:41 2026","acquiredAt":1778647461667}

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ yarn.lock
 /blob-report/
 .lighthouseci/
 .lighthouseci-report/
+.claude/scheduled_tasks.lock

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,25 +1,37 @@
-import * as Sentry from "@sentry/nextjs";
-
 /**
- * Sentry 클라이언트 초기화.
- * replayIntegration (~70KB) 은 lazyLoadIntegration 으로 분리 — 초기 번들에서 제외,
- * production 진입 후 CDN에서 비동기 fetch 해 addIntegration.
+ * Sentry 클라이언트 초기화 — 전체를 idle 시점으로 미룬다.
+ * 동기 init 은 Sentry SDK (~100KB) 가 첫 hydration JS 윈도우에 포함되어 TBT/LCP 압박.
+ * dynamic import 로 SDK 다운로드 자체를 LCP 이후로 분리.
+ *
+ * trade-off: 첫 paint 직후 발생하는 에러는 캡쳐 못 함. 대신 production perf 점수 회복.
  */
-Sentry.init({
-	dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-	tracesSampleRate: 0.1,
-	replaysSessionSampleRate: 0,
-	replaysOnErrorSampleRate: 1.0,
-	integrations: [Sentry.browserTracingIntegration()],
-	enabled: process.env.NODE_ENV === "production",
-});
 
-if (process.env.NODE_ENV === "production" && typeof window !== "undefined") {
-	Sentry.lazyLoadIntegration("replayIntegration")
-		.then((replayIntegration) => {
-			Sentry.addIntegration(replayIntegration());
-		})
-		.catch(() => {
-			/* CDN fetch 실패 시 replay 없이 진행 — tracing 은 여전히 동작. */
-		});
+if (typeof window !== "undefined" && process.env.NODE_ENV === "production") {
+	const init = () => {
+		import("@sentry/nextjs")
+			.then((Sentry) => {
+				Sentry.init({
+					dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+					tracesSampleRate: 0.1,
+					replaysSessionSampleRate: 0,
+					replaysOnErrorSampleRate: 1.0,
+					integrations: [Sentry.browserTracingIntegration()],
+				});
+
+				Sentry.lazyLoadIntegration("replayIntegration")
+					.then((replay) => Sentry.addIntegration(replay()))
+					.catch(() => {});
+			})
+			.catch(() => {
+				/* SDK fetch 실패 시 침묵 — 본 앱 동작에 영향 없음 */
+			});
+	};
+
+	const ric = (
+		window as Window & {
+			requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+		}
+	).requestIdleCallback;
+	if (ric) ric(init, { timeout: 3000 });
+	else setTimeout(init, 1500);
 }

--- a/src/features/cookie-consent/deferred/index.tsx
+++ b/src/features/cookie-consent/deferred/index.tsx
@@ -1,30 +1,35 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
-
-const CookieConsent = dynamic(() => import("src/features/cookie-consent/ui"), { ssr: false });
+import CookieConsent from "src/features/cookie-consent/ui";
 
 /**
  * @description
  * CookieConsent 의 mount 자체를 idle 시점까지 미루는 wrapper.
  * 첫 LCP/TBT 측정 윈도우 안에서 CookieConsent 의 hydration + DOM 작업이 안 일어나도록 분리.
- * idle 미지원 환경은 500ms setTimeout fallback.
+ * 부모(Providers)에서 이미 dynamic(ssr:false) 로 코드 청크가 분리됨 — 여기선 평범한 import.
+ * ric 에 2000ms timeout 부여 → 메인 스레드가 계속 바빠도 동의 배너가 영구히 안 보이는 일 방지.
  */
+const IDLE_TIMEOUT_MS = 2000;
+const FALLBACK_DELAY_MS = 500;
+
 const DeferredCookieConsent = () => {
 	const [shouldMount, setShouldMount] = useState(false);
 
 	useEffect(() => {
-		const ric = (window as Window & { requestIdleCallback?: (cb: () => void) => number })
-			.requestIdleCallback;
+		const ric = (
+			window as Window & {
+				requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+			}
+		).requestIdleCallback;
 		const cic = (window as Window & { cancelIdleCallback?: (id: number) => void })
 			.cancelIdleCallback;
 
 		if (ric && cic) {
-			const id = ric(() => setShouldMount(true));
+			const id = ric(() => setShouldMount(true), { timeout: IDLE_TIMEOUT_MS });
 			return () => cic(id);
 		}
-		const timer = setTimeout(() => setShouldMount(true), 500);
+		const timer = setTimeout(() => setShouldMount(true), FALLBACK_DELAY_MS);
 		return () => clearTimeout(timer);
 	}, []);
 

--- a/src/features/cookie-consent/deferred/index.tsx
+++ b/src/features/cookie-consent/deferred/index.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
+
+const CookieConsent = dynamic(() => import("src/features/cookie-consent/ui"), { ssr: false });
+
+/**
+ * @description
+ * CookieConsent 의 mount 자체를 idle 시점까지 미루는 wrapper.
+ * 첫 LCP/TBT 측정 윈도우 안에서 CookieConsent 의 hydration + DOM 작업이 안 일어나도록 분리.
+ * idle 미지원 환경은 500ms setTimeout fallback.
+ */
+const DeferredCookieConsent = () => {
+	const [shouldMount, setShouldMount] = useState(false);
+
+	useEffect(() => {
+		const ric = (window as Window & { requestIdleCallback?: (cb: () => void) => number })
+			.requestIdleCallback;
+		const cic = (window as Window & { cancelIdleCallback?: (id: number) => void })
+			.cancelIdleCallback;
+
+		if (ric && cic) {
+			const id = ric(() => setShouldMount(true));
+			return () => cic(id);
+		}
+		const timer = setTimeout(() => setShouldMount(true), 500);
+		return () => clearTimeout(timer);
+	}, []);
+
+	if (!shouldMount) return null;
+	return <CookieConsent />;
+};
+
+export default DeferredCookieConsent;

--- a/src/widgets/layout/provider/index.tsx
+++ b/src/widgets/layout/provider/index.tsx
@@ -2,11 +2,16 @@
 
 import { AlertProvider, ToastProvider } from "@bigtablet/design-system";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import dynamic from "next/dynamic";
 import { type ReactNode, useMemo } from "react";
-import CookieConsent from "src/features/cookie-consent/ui";
 import { isHttpError } from "src/shared/libs/api/error";
 import { createMutationCache } from "src/shared/libs/api/query/mutation-cache";
 import ToastBridgeProvider from "src/shared/libs/api/toast/toast-bridge-provider";
+
+/* CookieConsent 는 초기 hydration 차단 요인 — dynamic + idle 마운트 컴포넌트로 분리해 LCP 이후로 미룸 */
+const DeferredCookieConsent = dynamic(() => import("src/features/cookie-consent/deferred"), {
+	ssr: false,
+});
 
 type Props = { children: ReactNode };
 
@@ -38,7 +43,7 @@ export default function Providers({ children }: Props) {
 				<QueryClientProvider client={queryClient}>
 					<ToastBridgeProvider />
 					{children}
-					<CookieConsent />
+					<DeferredCookieConsent />
 				</QueryClientProvider>
 			</ToastProvider>
 		</AlertProvider>


### PR DESCRIPTION
## 제목
fix/perf-providers-sentry-cookie

## 작업한 내용
- [x] DeferredCookieConsent 추가 — dynamic + ssr:false + requestIdleCallback mount
- [x] sentry.client.config 전체 idle 시점 dynamic import (browserTracing + lazy replay)

trade-off: 첫 프레임 직후 에러는 Sentry 캡쳐 못 함. perf 회복 우선.

## 전달할 추가 이슈
- 없음

Closes #357