### PR TITLE
fix/css-render-blocking

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,14 @@ const nextConfig = {
 	/* X-Powered-By: Next.js 헤더 제거 — 서버 기술 스택 정보 노출 방지 */
 	poweredByHeader: false,
 
+	experimental: {
+		/* CSS 청크 7개로 split 되어 모바일 throttle 에서 8.4s render-blocking 발생.
+		   strict 로 chunk 수 줄여 HTTP request waterfall 단축. */
+		cssChunking: "strict",
+		/* Critters 로 critical CSS inline + 나머지 defer — initial paint 차단 제거. */
+		inlineCss: true,
+	},
+
 	images: {
 		remotePatterns: [
 			{


### PR DESCRIPTION
## 제목
fix/css-render-blocking

## 작업한 내용
- [x] experimental.cssChunking "strict" — 7개 CSS chunk 통합
- [x] experimental.inlineCss — Critters critical CSS 인라인

근거: Lighthouse 진단 결과 / mobile LCP 24.6s — render-blocking CSS 8.4s 차지. CSS waterfall 제거 시 FCP/LCP 대폭 단축 예상.

## 전달할 추가 이슈
- 없음

Closes #360