### PR TITLE
fix/e2e-route-main-to-root

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 
 /** API 의존 페이지(blog, news, recruit) 제외 — CI에서 API 미가용 시 렌더링 실패 */
 const pages = [
-	{ name: "main", path: "/main" },
+	{ name: "main", path: "/" },
 	{ name: "about", path: "/about" },
 	{ name: "privacy policy", path: "/policies/privacy" },
 	{ name: "terms", path: "/policies/terms" },

--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -2,21 +2,21 @@ import { expect, test } from "@playwright/test";
 
 test.describe("internationalization", () => {
 	test("default locale renders korean content", async ({ page }) => {
-		await page.goto("/main");
+		await page.goto("/");
 		await expect(page.locator("main")).toBeVisible();
 		await expect(page.getByRole("link", { name: "About Us" })).toBeVisible();
 	});
 
 	test("korean locale renders korean navigation", async ({ page, context, baseURL }) => {
 		await context.addCookies([{ name: "NEXT_LOCALE", value: "ko", url: baseURL }]);
-		await page.goto("/main");
+		await page.goto("/");
 		await expect(page.locator("main")).toBeVisible();
 		await expect(page.locator("header")).toBeVisible();
 	});
 
 	test("english locale renders english navigation", async ({ page, context, baseURL }) => {
 		await context.addCookies([{ name: "NEXT_LOCALE", value: "en", url: baseURL }]);
-		await page.goto("/main");
+		await page.goto("/");
 		await expect(page.locator("main")).toBeVisible();
 		await expect(page.locator("header")).toBeVisible();
 	});

--- a/e2e/main.spec.ts
+++ b/e2e/main.spec.ts
@@ -6,8 +6,8 @@ test.beforeEach(async ({ context, baseURL }) => {
 
 test.describe("main page", () => {
 	test("/main redirects to /", async ({ page }) => {
-		const response = await page.goto("/main");
-		expect(response?.url()).toMatch(/\/$/);
+		await page.goto("/main");
+		await expect(page).toHaveURL("/");
 	});
 
 	test("renders banner section with heading", async ({ page }) => {

--- a/e2e/main.spec.ts
+++ b/e2e/main.spec.ts
@@ -5,36 +5,36 @@ test.beforeEach(async ({ context, baseURL }) => {
 });
 
 test.describe("main page", () => {
-	test("/ redirects to /main", async ({ page }) => {
-		const response = await page.goto("/");
-		expect(response?.url()).toContain("/main");
+	test("/main redirects to /", async ({ page }) => {
+		const response = await page.goto("/main");
+		expect(response?.url()).toMatch(/\/$/);
 	});
 
 	test("renders banner section with heading", async ({ page }) => {
-		await page.goto("/main");
+		await page.goto("/");
 		await expect(page.locator("main")).toBeVisible();
 		await expect(page.getByRole("heading", { level: 1 })).toBeVisible({ timeout: 10_000 });
 	});
 
 	test("renders solution section", async ({ page }) => {
-		await page.goto("/main");
+		await page.goto("/");
 		await expect(page.getByText("솔루션 개요")).toBeVisible({ timeout: 10_000 });
 	});
 
 	test("renders partner section", async ({ page }) => {
-		await page.goto("/main");
+		await page.goto("/");
 		await expect(page.getByText("파트너사")).toBeVisible({ timeout: 10_000 });
 	});
 
 	test("renders footer with company info", async ({ page }) => {
-		await page.goto("/main");
+		await page.goto("/");
 		const footer = page.locator("footer");
 		await expect(footer).toBeVisible();
 		await expect(footer.getByText("Bigtablet, Inc.")).toBeVisible();
 	});
 
 	test("footer policy links navigate correctly", async ({ page }) => {
-		await page.goto("/main");
+		await page.goto("/");
 		const footer = page.locator("footer");
 		await expect(footer.getByText("개인정보처리방침")).toBeVisible({ timeout: 10_000 });
 		await footer.getByText("개인정보처리방침").click();

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -4,7 +4,7 @@ import { mockApiRoutes } from "./fixtures/mock-api";
 test.describe("header navigation", () => {
 	test.beforeEach(async ({ page }) => {
 		await mockApiRoutes(page);
-		await page.goto("/main");
+		await page.goto("/");
 	});
 
 	test("navigates to recruit page", async ({ page }) => {

--- a/e2e/policies.spec.ts
+++ b/e2e/policies.spec.ts
@@ -34,7 +34,7 @@ test.describe("policy pages - korean", () => {
 		const backLink = page.getByRole("link", { name: /홈/ });
 		await expect(backLink).toBeVisible({ timeout: 10_000 });
 		await backLink.click();
-		await expect(page).toHaveURL(/\/$/);
+		await expect(page).toHaveURL("/");
 	});
 });
 

--- a/e2e/policies.spec.ts
+++ b/e2e/policies.spec.ts
@@ -27,14 +27,14 @@ test.describe("policy pages - korean", () => {
 	}
 
 	test("policy page back link navigates to previous page", async ({ page }) => {
-		await page.goto("/main");
+		await page.goto("/");
 		await page.goto("/policies/privacy");
 		await expect(page.locator("main")).toBeVisible({ timeout: 10_000 });
 
 		const backLink = page.getByRole("link", { name: /홈/ });
 		await expect(backLink).toBeVisible({ timeout: 10_000 });
 		await backLink.click();
-		await expect(page).toHaveURL(/\/main/);
+		await expect(page).toHaveURL(/\/$/);
 	});
 });
 


### PR DESCRIPTION
## 제목
fix/e2e-route-main-to-root

## 작업한 내용
- [x] main/i18n/navigation/policies/accessibility 스펙들 `/main` → `/`
- [x] main.spec redirect 테스트 반전 (`/main` → `/`)
- [x] i18n 의 `/en/main`, `/ko/main` proxy locale-strip 테스트는 유지

## 전달할 추가 이슈
- 없음

Closes #362