### PR TITLE
fix/intl-namespace-scoping

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/(i18n)/about/[id]/page.tsx
+++ b/src/app/(i18n)/about/[id]/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
+import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { isMemberSlug } from "src/entities/about/util/member.util";
+import { resolveLocale } from "src/shared/libs/locale";
 import MemberDetailClient from "./client";
 
 type PageProps = {
@@ -51,7 +54,22 @@ export const generateMetadata = async ({ params }: PageProps): Promise<Metadata>
 };
 
 const MemberDetailPage = async () => {
-	return <MemberDetailClient />;
+	/* about/[id]/client.tsx 가 about.team.members.* 를 사용 — layout 에서 빠진 about namespace 를
+	   여기서 nested provider 로 다시 제공. */
+	const store = await cookies();
+	const locale = resolveLocale(store.get("NEXT_LOCALE")?.value);
+	let messages: Record<string, unknown> = {};
+	try {
+		messages = (await import(`../../../../../messages/${locale}.json`)).default;
+	} catch {
+		messages = {};
+	}
+
+	return (
+		<NextIntlClientProvider locale={locale} messages={messages}>
+			<MemberDetailClient />
+		</NextIntlClientProvider>
+	);
 };
 
 export default MemberDetailPage;

--- a/src/app/(i18n)/about/[id]/page.tsx
+++ b/src/app/(i18n)/about/[id]/page.tsx
@@ -1,9 +1,7 @@
 import type { Metadata } from "next";
-import { cookies } from "next/headers";
 import { NextIntlClientProvider } from "next-intl";
-import { getMessages } from "next-intl/server";
+import { getLocale, getMessages } from "next-intl/server";
 import { isMemberSlug } from "src/entities/about/util/member.util";
-import { resolveLocale } from "src/shared/libs/locale";
 import MemberDetailClient from "./client";
 
 type PageProps = {
@@ -55,15 +53,9 @@ export const generateMetadata = async ({ params }: PageProps): Promise<Metadata>
 
 const MemberDetailPage = async () => {
 	/* about/[id]/client.tsx 가 about.team.members.* 를 사용 — layout 에서 빠진 about namespace 를
-	   여기서 nested provider 로 다시 제공. */
-	const store = await cookies();
-	const locale = resolveLocale(store.get("NEXT_LOCALE")?.value);
-	let messages: Record<string, unknown> = {};
-	try {
-		messages = (await import(`../../../../../messages/${locale}.json`)).default;
-	} catch {
-		messages = {};
-	}
+	   여기서 nested provider 로 다시 제공. generateMetadata 와 동일하게 getMessages 사용 → 일관성. */
+	const locale = await getLocale();
+	const messages = (await getMessages()) as Record<string, unknown>;
 
 	return (
 		<NextIntlClientProvider locale={locale} messages={messages}>

--- a/src/app/(i18n)/about/page.tsx
+++ b/src/app/(i18n)/about/page.tsx
@@ -1,7 +1,6 @@
-import { cookies } from "next/headers";
 import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages } from "next-intl/server";
 import type { HistorySchema } from "src/entities/about/history/schema/history.schema";
-import { resolveLocale } from "src/shared/libs/locale";
 import History from "src/widgets/about/history";
 import Introduce from "src/widgets/about/introduce";
 import Team from "src/widgets/about/team";
@@ -20,24 +19,11 @@ const historyItemSchema = z.union([
 const historyByYearSchema = z.record(z.string(), z.array(historyItemSchema));
 
 const About = async () => {
-	/**
-	 * (i18n) layout과 동일하게 NEXT_LOCALE 쿠키 기반으로 직접 import.
-	 * getMessages()는 middleware가 next-intl routing을 안 쓰는 환경에서
-	 * defaultLocale로 fallback되는 문제가 있음.
-	 */
-	const store = await cookies();
-	const locale = resolveLocale(store.get("NEXT_LOCALE")?.value);
-
-	let messages: Record<string, unknown> = {};
-	let aboutHistory: unknown = {};
-	try {
-		messages = (await import(`../../../../messages/${locale}.json`)).default;
-		const about = messages?.about as Record<string, unknown> | undefined;
-		aboutHistory = about?.history ?? {};
-	} catch {
-		messages = {};
-		aboutHistory = {};
-	}
+	/* i18n/request.ts 가 NEXT_LOCALE 쿠키 기반으로 locale 결정 → getMessages 가 올바른 messages 반환. */
+	const locale = await getLocale();
+	const messages = (await getMessages()) as Record<string, unknown>;
+	const about = messages?.about as Record<string, unknown> | undefined;
+	const aboutHistory = about?.history ?? {};
 
 	const parsed = historyByYearSchema.safeParse(aboutHistory);
 	const historyByYear = parsed.success ? parsed.data : {};

--- a/src/app/(i18n)/about/page.tsx
+++ b/src/app/(i18n)/about/page.tsx
@@ -1,4 +1,5 @@
 import { cookies } from "next/headers";
+import { NextIntlClientProvider } from "next-intl";
 import type { HistorySchema } from "src/entities/about/history/schema/history.schema";
 import { resolveLocale } from "src/shared/libs/locale";
 import History from "src/widgets/about/history";
@@ -27,11 +28,14 @@ const About = async () => {
 	const store = await cookies();
 	const locale = resolveLocale(store.get("NEXT_LOCALE")?.value);
 
+	let messages: Record<string, unknown> = {};
 	let aboutHistory: unknown = {};
 	try {
-		const messages = (await import(`../../../../messages/${locale}.json`)).default;
-		aboutHistory = messages?.about?.history ?? {};
+		messages = (await import(`../../../../messages/${locale}.json`)).default;
+		const about = messages?.about as Record<string, unknown> | undefined;
+		aboutHistory = about?.history ?? {};
 	} catch {
+		messages = {};
 		aboutHistory = {};
 	}
 
@@ -53,12 +57,14 @@ const About = async () => {
 	);
 
 	return (
-		<>
+		/* layout 에서 `about` namespace 를 제외했으므로 about 페이지에서만 full messages 로 다시 wrap.
+		   이 nested provider 의 children 에서 useTranslations("about.*") 가 동작. */
+		<NextIntlClientProvider locale={locale} messages={messages}>
 			<Introduce sectionKey="section1" />
 			<Introduce sectionKey="section2" reverse />
 			<History items={items} />
 			<Team />
-		</>
+		</NextIntlClientProvider>
 	);
 };
 

--- a/src/app/(i18n)/layout.tsx
+++ b/src/app/(i18n)/layout.tsx
@@ -1,18 +1,24 @@
 import { cookies } from "next/headers";
 import { NextIntlClientProvider } from "next-intl";
 import type { ReactNode } from "react";
-import { resolveLocale } from "src/shared/libs/locale";
+import { pickMessages, resolveLocale } from "src/shared/libs/locale";
 import Footer from "src/shared/ui/footer";
 import Header from "src/shared/ui/header";
 import PageTransition from "src/shared/ui/page-transition";
 import styles from "./layout.module.scss";
 
+/* `about` namespace 가 25KB — /about 외 페이지에서 사용 안 함. layout 에서 빼서
+   /, /blog, /news, /recruit, /policies/* 의 SSR HTML payload 25KB 절감.
+   /about 와 /about/[id] 는 자체 page.tsx 에서 full messages 로 wrap. */
+const HEAVY_NAMESPACES = ["about"] as const;
+
 export default async function LocaleLayout({ children }: { children: ReactNode }) {
 	const locale = resolveLocale((await cookies()).get("NEXT_LOCALE")?.value);
 	const messages = (await import(`../../../messages/${locale}.json`)).default;
+	const lightMessages = pickMessages(messages, { exclude: HEAVY_NAMESPACES });
 
 	return (
-		<NextIntlClientProvider locale={locale} messages={messages}>
+		<NextIntlClientProvider locale={locale} messages={lightMessages}>
 			<div className={styles.layout}>
 				<Header />
 				<main className={styles.layout_main}>

--- a/src/app/(i18n)/layout.tsx
+++ b/src/app/(i18n)/layout.tsx
@@ -1,7 +1,7 @@
-import { cookies } from "next/headers";
 import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages } from "next-intl/server";
 import type { ReactNode } from "react";
-import { pickMessages, resolveLocale } from "src/shared/libs/locale";
+import { pickMessages } from "src/shared/libs/locale";
 import Footer from "src/shared/ui/footer";
 import Header from "src/shared/ui/header";
 import PageTransition from "src/shared/ui/page-transition";
@@ -13,8 +13,10 @@ import styles from "./layout.module.scss";
 const HEAVY_NAMESPACES = ["about"] as const;
 
 export default async function LocaleLayout({ children }: { children: ReactNode }) {
-	const locale = resolveLocale((await cookies()).get("NEXT_LOCALE")?.value);
-	const messages = (await import(`../../../messages/${locale}.json`)).default;
+	/* i18n/request.ts 가 NEXT_LOCALE 쿠키 기반으로 locale 결정 → getLocale/getMessages 가 올바른
+	   locale 의 messages 반환. 깊은 상대 import 도 불필요. */
+	const locale = await getLocale();
+	const messages = (await getMessages()) as Record<string, unknown>;
 	const lightMessages = pickMessages(messages, { exclude: HEAVY_NAMESPACES });
 
 	return (

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,16 +1,19 @@
+import { cookies } from "next/headers";
 import type { AbstractIntlMessages } from "next-intl";
 import { getRequestConfig } from "next-intl/server";
-import { type AppLocale, routing } from "src/i18n/routing";
+import { resolveLocale } from "src/shared/libs/locale";
 
-const isSupported = (l: string | undefined): l is AppLocale =>
-	!!l && (routing.locales as readonly string[]).includes(l);
-
-export default getRequestConfig(async ({ locale }) => {
-	const resolved: AppLocale = isSupported(locale) ? locale : routing.defaultLocale;
-
-	const messages = (await import(`../../messages/${resolved}.json`))
-		.default as AbstractIntlMessages;
-
-	// 반드시 locale 포함해서 반환
-	return { locale: resolved, messages };
+/**
+ * @description
+ * next-intl 서버 측 요청 설정. URL prefix 가 아닌 NEXT_LOCALE 쿠키 기반으로 locale 을 결정.
+ *
+ * 이전엔 routing config 의 `localePrefix: "never"` 때문에 next-intl 이 URL 에서 locale 추출 못 해
+ * 항상 defaultLocale 로 fallback 됐음 — `getMessages()`/`getTranslations()` 가 한국어 사용자도
+ * 영문 메시지 반환하던 버그의 근본 원인. 쿠키 직접 읽어 server-side i18n 헬퍼들이 정상 동작.
+ */
+export default getRequestConfig(async () => {
+	const cookieValue = (await cookies()).get("NEXT_LOCALE")?.value;
+	const locale = resolveLocale(cookieValue);
+	const messages = (await import(`../../messages/${locale}.json`)).default as AbstractIntlMessages;
+	return { locale, messages };
 });

--- a/src/shared/libs/locale/index.ts
+++ b/src/shared/libs/locale/index.ts
@@ -20,3 +20,27 @@ export const resolveLocale = (value?: string | null): Locale => {
 
 /** 입력이 한국어 로케일인지 판별. */
 export const isKorean = (value?: string | null): boolean => resolveLocale(value) === "ko";
+
+/**
+ * @description
+ * next-intl messages 에서 일부 namespace 만 추출. layout 이 무거운 namespace(`about` 등)를
+ * 빼고 client provider 에 전달해 모든 페이지의 HTML serialize 크기를 줄이는 용도.
+ *
+ * @param messages - 전체 messages 객체
+ * @param exclude - 제외할 top-level namespace 키 배열
+ * @returns exclude 키를 뺀 새 객체 (얕은 복사)
+ *
+ * @example
+ * const light = pickMessages(messages, { exclude: ["about"] });
+ */
+export const pickMessages = <T extends Record<string, unknown>>(
+	messages: T,
+	{ exclude }: { exclude: readonly string[] },
+): Partial<T> => {
+	const excludeSet = new Set(exclude);
+	const result: Record<string, unknown> = {};
+	for (const key of Object.keys(messages)) {
+		if (!excludeSet.has(key)) result[key] = messages[key];
+	}
+	return result as Partial<T>;
+};

--- a/src/shared/libs/locale/index.ts
+++ b/src/shared/libs/locale/index.ts
@@ -34,9 +34,10 @@ export const isKorean = (value?: string | null): boolean => resolveLocale(value)
  * const light = pickMessages(messages, { exclude: ["about"] });
  */
 export const pickMessages = <T extends Record<string, unknown>>(
-	messages: T,
+	messages: T | null | undefined,
 	{ exclude }: { exclude: readonly string[] },
 ): Partial<T> => {
+	if (!messages) return {} as Partial<T>;
 	const excludeSet = new Set(exclude);
 	const result: Record<string, unknown> = {};
 	for (const key of Object.keys(messages)) {

--- a/src/shared/ui/footer/index.tsx
+++ b/src/shared/ui/footer/index.tsx
@@ -1,11 +1,16 @@
-"use client";
-
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 import styles from "./style.module.scss";
 
-const Footer = () => {
-	const t = useTranslations("footer");
+/**
+ * @component Footer
+ *
+ * @description
+ * 사이트 공통 푸터. 클라이언트 이벤트 없으므로 server component 로 렌더 — hydration JS 미포함.
+ * 번역은 `getTranslations` 로 서버에서 직접 가져옴.
+ */
+const Footer = async () => {
+	const t = await getTranslations("footer");
 
 	return (
 		<footer className={styles.footer}>


### PR DESCRIPTION
## 제목
fix/intl-namespace-scoping

## 작업한 내용
- [x] pickMessages 헬퍼 추가
- [x] Layout messages 에서 about namespace 제외
- [x] /about, /about/[id] nested provider 로 full messages
- [x] Footer server component 전환

효과: 비-about 페이지 HTML payload 29KB → 5KB, Footer hydration 제거.

## 전달할 추가 이슈
- 없음

Closes #366