### PR TITLE
fix/about-introduce-image-loading

### DIFF
--- a/src/widgets/about/introduce/index.tsx
+++ b/src/widgets/about/introduce/index.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import clsx from "clsx";
-import Image from "next/image";
 import { useTranslations } from "next-intl";
+import ImageThumb from "src/shared/ui/image-thumb";
 import styles from "./style.module.scss";
 
 interface AboutSchema {
@@ -20,11 +20,12 @@ const Introduce = ({ sectionKey, reverse = false }: AboutSchema) => {
 				<p className={styles.introduce_desc}>{t(`${sectionKey}.description`)}</p>
 			</div>
 			<div className={styles.introduce_image} aria-hidden="true">
-				<Image
+				{/* ImageThumb 가 loading shimmer + 공간 예약. 이전엔 raw Image 가 .introduce_img 의
+				    width:auto / height:auto 와 충돌해 로드 전 0 size 로 붕괴 → layout shift 발생.
+				    container 의 aspect-ratio 가 슬롯을 고정한다. */}
+				<ImageThumb
 					src="/images/logo/img.webp"
 					alt="Bigtablet 로고"
-					width={420}
-					height={420}
 					sizes="(max-width: 768px) 280px, 420px"
 					className={styles.introduce_img}
 				/>

--- a/src/widgets/about/introduce/style.module.scss
+++ b/src/widgets/about/introduce/style.module.scss
@@ -66,20 +66,24 @@
 }
 
 .introduce_image {
-  /* flex:1 이면 절반을 무조건 차지해 이미지가 작아도 빈 공간이 생김.
-     자연 폭 기반 + max-width로 제한 — 텍스트와 시각적으로 가까이 */
+  /* 정사각 슬롯을 고정해 이미지 로드 전에도 공간 예약 — 로드 직후 layout shift 차단.
+     flex:0 1 auto + max-width 로 텍스트와 자연스럽게 옆에 배치. */
   flex: 0 1 auto;
+  width: 100%;
   max-width: 360px;
+  aspect-ratio: 1 / 1;
   @include token.flex_center;
 }
 
+/* ImageThumb wrapper 가 fill 모드 — 부모 슬롯을 채움. img 자체는 contain. */
 .introduce_img {
-  max-width: 100%;
-  max-height: 420px;
-  width: auto;
-  height: auto;
-  object-fit: contain;
-  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: token.$radius_md;
+
+  :global(img) {
+    object-fit: contain;
+  }
 }
 
 @include token.mobile {
@@ -103,10 +107,7 @@
     width: 100%;
     max-width: 280px;
     margin: 0 auto;
-
-    .introduce_img {
-      max-height: 200px;
-    }
+    /* aspect-ratio: 1/1 은 데스크탑 규칙에서 상속 — 모바일도 정사각 슬롯 유지 */
   }
 
   .introduce_title {


### PR DESCRIPTION
## 제목
fix/about-introduce-image-loading

## 작업한 내용
- [x] /about Introduce 위젯 raw Image → ImageThumb (shimmer + 공간 예약)
- [x] .introduce_image 에 aspect-ratio 1/1 + width 100% 로 슬롯 고정
- [x] 이전 width:auto/height:auto override 제거

원인: raw Image width={420} height={420} 가 .introduce_img 의 width:auto 와 충돌 → 0 size 붕괴 → layout shift.

## 전달할 추가 이슈
- 없음

Closes #368