### PR TITLE
fix/responsive-i18n-sweep

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -108,7 +108,14 @@ const nextConfig = {
 	},
 
 	sassOptions: {
-		includePaths: ["./src/shared/styles"],
+		/* DS 3.1 dist/styles 를 load path 에 추가 — package exports 가 scss/token 외
+		   서브패스를 막아(ERR_PACKAGE_PATH_NOT_EXPORTED) 직접 import 불가하므로,
+		   심링크 경로를 직접 노출해 _ds-token.scss 가 개별 서브모듈(spacing 등)을
+		   @forward 할 수 있게 한다. 우리 src/shared/styles 가 우선(같은 이름이면 먼저 매치).
+		   modern Sass API 는 loadPaths 를 사용(includePaths 는 legacy 라 무시됨) —
+		   둘 다 지정해 sass-loader api 버전과 무관하게 동작. */
+		loadPaths: ["./src/shared/styles", "./node_modules/@bigtablet/design-system/dist/styles"],
+		includePaths: ["./src/shared/styles", "./node_modules/@bigtablet/design-system/dist/styles"],
 	},
 };
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"prepare": "husky"
 	},
 	"dependencies": {
-		"@bigtablet/design-system": "1.22.0",
+		"@bigtablet/design-system": "3.1.1",
 		"@gsap/react": "^2.1.2",
 		"@hookform/resolvers": "^5.4.0",
 		"@next/bundle-analyzer": "^16.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     dependencies:
       '@bigtablet/design-system':
-        specifier: 1.22.0
-        version: 1.22.0(lucide-react@1.16.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.1.1
+        version: 3.1.1(lucide-react@1.16.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@gsap/react':
         specifier: ^2.1.2
         version: 2.1.2(gsap@3.15.0)(react@19.2.6)
@@ -277,11 +277,11 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bigtablet/design-system@1.22.0':
-    resolution: {integrity: sha512-cIHPoUVmKheIhxJ89YI0n7T3DkQRgwaCK45WpZhvIJu0nTQayj6TU8sE//VXRC9iIVvCFv0n7V+rYmdrYNAPMQ==}
+  '@bigtablet/design-system@3.1.1':
+    resolution: {integrity: sha512-kKmr3RbHlZMPJ4In7SBmczAKmWf0Mhgjpx/hhavWXyvRJoRGw/8V7sS4rITrigg71gvt+jUlUZRa53aQowA8TQ==}
     peerDependencies:
       lucide-react: '>=0.552.0'
-      next: '*'
+      next: '>=16'
       react: ^19
       react-dom: ^19
     peerDependenciesMeta:
@@ -1528,6 +1528,33 @@ packages:
     resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
     peerDependencies:
       '@opentelemetry/api': ^1.8
+
+  '@react-spring/animated@10.1.0':
+    resolution: {integrity: sha512-dvGVSfNYhbkzTAnyB1S1940ZiKp6/Ey+b2vQc70dJ5k6gzH/GdlfeDzCh65V94b6OPqF7Xl4VUICVUQpc07iUg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-spring/core@10.1.0':
+    resolution: {integrity: sha512-XUG3UCCCxay6lYjBU2KOKzEgC1sx/w44ouB5gRh2Ex6rVJOdPcGVg7JJUIOAQo7uhKGfQdCQU4qUZaQnmInZPQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-spring/rafz@10.1.0':
+    resolution: {integrity: sha512-e/LRnNmvmg8Agl4j3MGcjHuSTSBcCrxr3xeoWdodxpLWeTHY1pHl8PJDOCEJ2Pj6BMdEBaWFRAX7uxRo1FLzCg==}
+
+  '@react-spring/shared@10.1.0':
+    resolution: {integrity: sha512-ogIUujWxdwcsQ2Vp2hZs+KehvH8tKeWGHsFb1eRBYoePzhKS541Qg1JfFlQ7ursBUwwPDBQ5Wpwn+Cwx6WV1PQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-spring/types@10.1.0':
+    resolution: {integrity: sha512-RkJAlkAZ5yZSRBMOSidamioBHLjf8wGKbtr3pZ5iKoHFNQuNM2k6DqJDIEUcNQlWRZXny6Eqys2c9NdugdbdyQ==}
+
+  '@react-spring/web@10.1.0':
+    resolution: {integrity: sha512-mIj/lJ+1eI4tLSkIloaSNjmuriTDZY9bbQ/GFGcbVGfOKzWb5JOMMKiuHACh8J3m0+se3KqcWdg/JoALVloE7g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@rolldown/binding-android-arm64@1.0.0-rc.18':
     resolution: {integrity: sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==}
@@ -4253,8 +4280,9 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bigtablet/design-system@1.22.0(lucide-react@1.16.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@bigtablet/design-system@3.1.1(lucide-react@1.16.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
+      '@react-spring/web': 10.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       lucide-react: 1.16.0(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -5270,6 +5298,39 @@ snapshots:
       '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
+
+  '@react-spring/animated@10.1.0(react@19.2.6)':
+    dependencies:
+      '@react-spring/shared': 10.1.0(react@19.2.6)
+      '@react-spring/types': 10.1.0
+      react: 19.2.6
+
+  '@react-spring/core@10.1.0(react@19.2.6)':
+    dependencies:
+      '@react-spring/animated': 10.1.0(react@19.2.6)
+      '@react-spring/shared': 10.1.0(react@19.2.6)
+      '@react-spring/types': 10.1.0
+      react: 19.2.6
+
+  '@react-spring/rafz@10.1.0': {}
+
+  '@react-spring/shared@10.1.0(react@19.2.6)':
+    dependencies:
+      '@react-spring/rafz': 10.1.0
+      '@react-spring/types': 10.1.0
+      react: 19.2.6
+
+  '@react-spring/types@10.1.0': {}
+
+  '@react-spring/web@10.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@react-spring/animated': 10.1.0(react@19.2.6)
+      '@react-spring/core': 10.1.0(react@19.2.6)
+      '@react-spring/shared': 10.1.0(react@19.2.6)
+      '@react-spring/types': 10.1.0
+      csstype: 3.2.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   '@rolldown/binding-android-arm64@1.0.0-rc.18':
     optional: true

--- a/src/app/(i18n)/about/[id]/client.tsx
+++ b/src/app/(i18n)/about/[id]/client.tsx
@@ -32,6 +32,10 @@ const MemberDetailClient = () => {
 
 	return (
 		<section className={styles.member_detail} aria-label="Team member detail">
+			<div className={styles.member_detail_top}>
+				<BackLink href="/about#team" label={t("common.backToTeam")} />
+			</div>
+
 			<div className={styles.member_detail_inner}>
 				<Profile
 					name={name}
@@ -42,8 +46,6 @@ const MemberDetailClient = () => {
 				/>
 				<Interview items={qaList} />
 			</div>
-
-			<BackLink href="/about#team" label={t("common.backToTeam")} />
 		</section>
 	);
 };

--- a/src/app/(i18n)/about/[id]/style.module.scss
+++ b/src/app/(i18n)/about/[id]/style.module.scss
@@ -1,37 +1,42 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .member_detail {
-  color: token.$text_inverse;
-  padding-block: token.$spacing_2xl token.$spacing_3xl;
-  padding-inline: token.$spacing_md;
+  color: token.$color_text_inverse;
+  padding-block: token.$spacing_24 28px;
+  padding-inline: token.$spacing_12;
   display: grid;
   place-items: center;
-  row-gap: token.$spacing_md;
+  row-gap: token.$spacing_12;
+
+  &_top {
+    inline-size: min(1100px, 92vw);
+    margin-bottom: token.$spacing_8;
+  }
 
   &_inner {
     inline-size: min(1100px, 92vw);
     display: grid;
     grid-template-columns: 360px 1fr;
-    column-gap: token.$spacing_2xl;
+    column-gap: token.$spacing_24;
     align-items: start;
   }
 
 }
 
-@include token.mobile {
+@include token.compact {
   .member_detail {
     &_inner {
       grid-template-columns: 1fr;
-      row-gap: token.$spacing_lg;
+      row-gap: token.$spacing_16;
     }
   }
 }
 
-@include token.tablet {
+@include token.medium {
   .member_detail {
     &_inner {
       grid-template-columns: 1fr;
-      row-gap: token.$spacing_lg;
+      row-gap: token.$spacing_16;
     }
   }
 }

--- a/src/app/(i18n)/blog/[idx]/style.module.scss
+++ b/src/app/(i18n)/blog/[idx]/style.module.scss
@@ -1,19 +1,19 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .blog_detail {
   width: 100%;
-  padding: token.$spacing_2xl 0 token.$spacing_3xl;
+  padding: token.$spacing_24 0 28px;
   max-width: 960px;
   margin: 0 auto;
-  color: token.$text_normal;
+  color: token.$color_text_body;
 
   &_loading,
   &_empty {
-    @include token.body_regular;
-    font-size: token.$font_size_sm;
-    color: token.$text_subtle;
+    @include token.body_medium;
+    font-size: token.$font_size_14;
+    color: token.$color_text_caption;
     text-align: center;
-    margin-top: token.$spacing_2xl;
+    margin-top: token.$spacing_24;
   }
 
   &_body {
@@ -21,23 +21,23 @@
   }
 
   &_title {
-    @include token.heading_2;
-    font-size: token.$font_size_2xl;
-    color: token.$text_strong;
-    margin-bottom: token.$spacing_sm;
+    @include token.heading_medium_bold;
+    font-size: token.$font_size_24;
+    color: token.$color_text_heading;
+    margin-bottom: token.$spacing_8;
   }
 
   &_meta {
     display: flex;
     align-items: center;
-    gap: token.$spacing_sm;
-    color: token.$text_subtle;
-    font-size: token.$font_size_xs;
-    margin-bottom: token.$spacing_md;
+    gap: token.$spacing_8;
+    color: token.$color_text_caption;
+    font-size: token.$font_size_12;
+    margin-bottom: token.$spacing_12;
   }
 
   &_time {
-    @include token.body_regular;
+    @include token.body_medium;
   }
 
   &_dot {
@@ -45,15 +45,15 @@
   }
 
   &_views {
-    @include token.body_medium;
+    @include token.body_medium_medium;
   }
 
   &_hero {
     width: 100%;
     aspect-ratio: 16 / 9;
     border-radius: token.$radius_lg;
-    border: 1px solid token.$color_border;
-    margin: token.$spacing_lg 0 token.$spacing_xl;
+    border: 1px solid token.$color_border_default;
+    margin: token.$spacing_16 0 token.$spacing_20;
 
     img {
       object-fit: cover;
@@ -64,22 +64,22 @@
   }
 
   &_content {
-    @include token.body_regular;
-    font-size: token.$font_size_md;
-    color: token.$text_normal;
+    @include token.body_medium;
+    font-size: token.$font_size_16;
+    color: token.$color_text_body;
     white-space: pre-wrap;
 
     h1,
     h2,
     h3 {
-      margin-top: token.$spacing_2xl;
-      margin-bottom: token.$spacing_md;
+      margin-top: token.$spacing_24;
+      margin-bottom: token.$spacing_12;
       font-weight: token.$font_weight_bold;
-      color: token.$text_strong;
+      color: token.$color_text_heading;
     }
 
     p {
-      margin-bottom: token.$spacing_lg;
+      margin-bottom: token.$spacing_16;
     }
 
     img {
@@ -87,8 +87,42 @@
       max-width: 100%;
       height: auto;
       border-radius: token.$radius_md;
-      margin: token.$spacing_2xl auto;
-      border: 1px solid token.$color_border;
+      margin: token.$spacing_24 auto;
+      border: 1px solid token.$color_border_default;
+    }
+  }
+
+  @include token.compact {
+    padding: token.$spacing_20 token.$spacing_12 28px;
+
+    &_title {
+      font-size: token.$font_size_20;
+    }
+
+    &_meta {
+      flex-wrap: wrap;
+      font-size: token.$font_size_12;
+      margin-bottom: token.$spacing_8;
+    }
+
+    &_hero {
+      aspect-ratio: 4 / 3;
+      margin: token.$spacing_12 0 token.$spacing_16;
+    }
+
+    &_content {
+      font-size: token.$font_size_14;
+
+      h1,
+      h2,
+      h3 {
+        margin-top: token.$spacing_20;
+        margin-bottom: token.$spacing_8;
+      }
+
+      p {
+        margin-bottom: token.$spacing_12;
+      }
     }
   }
 }

--- a/src/app/(i18n)/blog/style.module.scss
+++ b/src/app/(i18n)/blog/style.module.scss
@@ -1,31 +1,31 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .blog_page {
   width: 100%;
-  padding: token.$spacing_2xl 0 token.$spacing_3xl;
+  padding: token.$spacing_24 0 28px;
 }
 
 .blog_page_title {
-  @include token.heading_2;
-  font-size: token.$font_size_2xl;
-  margin-bottom: token.$spacing_2xl;
-  color: token.$text_strong;
+  @include token.heading_medium_bold;
+  font-size: token.$font_size_24;
+  margin-bottom: token.$spacing_24;
+  color: token.$color_text_heading;
   text-align: center;
 }
 
 .blog_page_grid {
   display: grid;
   grid-template-columns: repeat(1, minmax(0, 1fr));
-  gap: token.$spacing_xl;
+  gap: token.$spacing_20;
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;
 
-  @include token.tablet {
+  @include token.medium {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  @include token.laptop {
+  @include token.expanded {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
@@ -35,9 +35,9 @@
 }
 
 .blog_page_empty {
-  @include token.body_regular;
-  font-size: token.$font_size_lg;
-  margin-top: token.$spacing_2xl;
-  color: token.$text_subtle;
+  @include token.body_medium;
+  font-size: token.$font_size_18;
+  margin-top: token.$spacing_24;
+  color: token.$color_text_caption;
   text-align: center;
 }

--- a/src/app/(i18n)/layout.module.scss
+++ b/src/app/(i18n)/layout.module.scss
@@ -1,11 +1,11 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .layout {
     display: flex;
     flex-direction: column;
     min-height: 100dvh;
-    background-color: token.$color_background_secondary;
-    color: token.$text_normal;
+    background-color: token.$color_bg_solid_dim;
+    color: token.$color_text_body;
 }
 
 /* sticky footer — main이 남는 공간 모두 차지해 footer를 viewport 하단으로 밀어냄 */

--- a/src/app/(i18n)/news/style.module.scss
+++ b/src/app/(i18n)/news/style.module.scss
@@ -1,14 +1,14 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .news_page {
   @include token.flex_column;
   width: 100%;
-  padding: token.$spacing_3xl 0 token.$spacing_5xl;
+  padding: 28px 0 36px;
   justify-content: center;
 }
 
 .news_page_pagination {
   display: flex;
   justify-content: center;
-  margin-top: token.$spacing_3xl;
+  margin-top: 28px;
 }

--- a/src/app/(i18n)/recruit/[idx]/apply/style.module.scss
+++ b/src/app/(i18n)/recruit/[idx]/apply/style.module.scss
@@ -1,19 +1,19 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .apply {
   @include token.flex_column_center;
   width: 100%;
-  padding: token.$spacing_xl 0 token.$spacing_5xl;
-  border-top: 1px solid token.$color_border;
+  padding: token.$spacing_20 0 36px;
+  border-top: 1px solid token.$color_border_default;
   align-items: center;
 }
 
 .apply_title {
-  @include token.heading_2;
-  font-size: token.$font_size_2xl;
-  color: token.$text_strong;
+  @include token.heading_medium_bold;
+  font-size: token.$font_size_24;
+  color: token.$color_text_heading;
   width: 100%;
   max-width: 880px;
-  margin: 0 auto token.$spacing_lg auto;
+  margin: 0 auto token.$spacing_16 auto;
   text-align: left;
 }

--- a/src/app/(i18n)/recruit/[idx]/apply/success/style.module.scss
+++ b/src/app/(i18n)/recruit/[idx]/apply/success/style.module.scss
@@ -1,20 +1,20 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .success {
-  @include token.flex-column-center;
+  @include token.flex_column_center;
   flex: 1 0 auto;
-  gap: token.$spacing_xl;
-  padding: token.$spacing_3xl;
+  gap: token.$spacing_20;
+  padding: 28px;
   text-align: center;
 }
 
 .success_title {
-  @include token.heading-2;
-  color: token.$text_strong;
+  @include token.heading_medium_bold;
+  color: token.$color_text_heading;
 }
 
 .success_text {
-  @include token.body-regular;
-  color: token.$text_normal;
-  line-height: token.$line_height_relaxed;
+  @include token.body_medium;
+  color: token.$color_text_body;
+  line-height: 1.75;
 }

--- a/src/app/(i18n)/recruit/[idx]/style.module.scss
+++ b/src/app/(i18n)/recruit/[idx]/style.module.scss
@@ -1,84 +1,84 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .recruit_detail {
   width: 100%;
   max-width: 960px;
   margin: 0 auto;
-  padding: token.$spacing_5xl token.$spacing_xl;
-  color: token.$text_normal;
+  padding: 36px token.$spacing_20;
+  color: token.$color_text_body;
 }
 
 .recruit_detail_loading,
 .recruit_detail_error {
   text-align: center;
-  font-size: token.$font_size_md;
-  color: token.$text_subtle;
-  padding: token.$spacing_5xl 0;
+  font-size: token.$font_size_16;
+  color: token.$color_text_caption;
+  padding: 36px 0;
 }
 
 .recruit_detail_header {
-  margin-bottom: token.$spacing_3xl;
-  border-bottom: 1px solid token.$color_border_light;
-  padding-bottom: token.$spacing_lg;
+  margin-bottom: 28px;
+  border-bottom: 1px solid token.$color_border_subtle;
+  padding-bottom: token.$spacing_16;
 }
 
 .recruit_detail_title {
-  @include token.heading_2;
-  font-size: token.$font_size_3xl;
-  color: token.$text_strong;
-  margin: 0 0 token.$spacing_lg;
+  @include token.heading_medium_bold;
+  font-size: token.$font_size_32;
+  color: token.$color_text_heading;
+  margin: 0 0 token.$spacing_16;
 }
 
 .recruit_detail_meta {
   @include token.flex_between;
   align-items: center;
-  gap: token.$spacing_md;
+  gap: token.$spacing_12;
   flex-wrap: wrap;
 }
 
 .recruit_detail_chips {
   display: flex;
   flex-wrap: wrap;
-  gap: token.$spacing_sm;
+  gap: token.$spacing_8;
 }
 
 .chip {
   display: inline-flex;
   align-items: center;
   height: 28px;
-  padding: 0 token.$spacing_md;
+  padding: 0 token.$spacing_12;
   border-radius: token.$radius_full;
-  background: token.$color_background;
-  border: 1px solid token.$color_border;
-  color: token.$text_normal;
-  font-size: token.$font_size_sm;
+  background: token.$color_bg_solid;
+  border: 1px solid token.$color_border_default;
+  color: token.$color_text_body;
+  font-size: token.$font_size_14;
   white-space: nowrap;
 }
 
 .recruit_detail_datebar {
   display: inline-flex;
   align-items: center;
-  color: token.$text_subtle;
-  font-size: token.$font_size_sm;
+  color: token.$color_text_caption;
+  font-size: token.$font_size_14;
   white-space: nowrap;
   height: 28px;
 }
 
 .recruit_detail_section {
-  margin-bottom: token.$spacing_4xl;
+  margin-bottom: token.$spacing_32;
 }
 
 .recruit_detail_section h2 {
-  @include token.heading_3;
-  font-size: token.$font_size_xl;
-  color: token.$text_normal;
-  margin: 0 0 token.$spacing_md;
+  @include token.heading_small_bold;
+  font-size: token.$font_size_20;
+  color: token.$color_text_body;
+  margin: 0 0 token.$spacing_12;
 }
 
 .recruit_detail_text {
-  font-size: token.$font_size_md;
-  color: token.$text_normal;
-  line-height: token.$line_height_relaxed;
+  font-size: token.$font_size_16;
+  color: token.$color_text_body;
+  line-height: 1.75;
   white-space: pre-line;
 }
 
@@ -86,7 +86,7 @@
 .recruit_detail_list,
 .recruit_detail_list ul,
 .recruit_detail_list ol {
-  padding-left: token.$spacing_xl;
+  padding-left: token.$spacing_20;
 }
 
 .recruit_detail_list ul {
@@ -98,61 +98,61 @@
 }
 
 .recruit_detail_list li {
-  font-size: token.$font_size_md;
-  line-height: token.$line_height_relaxed;
-  color: token.$text_normal;
+  font-size: token.$font_size_16;
+  line-height: 1.75;
+  color: token.$color_text_body;
 }
 
 .recruit_detail_process {
-  font-size: token.$font_size_md;
-  color: token.$text_normal;
+  font-size: token.$font_size_16;
+  color: token.$color_text_body;
   letter-spacing: 0.02em;
   word-spacing: 2px;
   white-space: pre-line;
 }
 
 .recruit_detail_notice {
-  margin-bottom: token.$spacing_4xl;
-  padding: token.$spacing_xl;
+  margin-bottom: token.$spacing_32;
+  padding: token.$spacing_20;
   border-radius: token.$radius_lg;
-  background: token.$color_background_secondary;
-  border: 1px solid token.$color_border_light;
+  background: token.$color_bg_solid_dim;
+  border: 1px solid token.$color_border_subtle;
 }
 
 .recruit_detail_notice_title {
-  @include token.heading_3;
-  font-size: token.$font_size_lg;
-  color: token.$text_strong;
-  margin: 0 0 token.$spacing_sm;
+  @include token.heading_small_bold;
+  font-size: token.$font_size_18;
+  color: token.$color_text_heading;
+  margin: 0 0 token.$spacing_8;
 }
 
 .recruit_detail_notice_text {
-  @include token.body_regular;
-  font-size: token.$font_size_sm;
-  color: token.$text_normal;
-  line-height: token.$line_height_relaxed;
-  margin: 0 0 token.$spacing_sm;
+  @include token.body_medium;
+  font-size: token.$font_size_14;
+  color: token.$color_text_body;
+  line-height: 1.75;
+  margin: 0 0 token.$spacing_8;
 }
 
 .recruit_detail_notice_list {
-  margin: 0 0 token.$spacing_sm;
-  padding-left: token.$spacing_xl;
+  margin: 0 0 token.$spacing_8;
+  padding-left: token.$spacing_20;
   list-style-type: disc;
 }
 
 .recruit_detail_notice_list li {
-  @include token.body_regular;
-  font-size: token.$font_size_sm;
-  color: token.$text_normal;
-  line-height: token.$line_height_relaxed;
+  @include token.body_medium;
+  font-size: token.$font_size_14;
+  color: token.$color_text_body;
+  line-height: 1.75;
 }
 
 .recruit_detail_request {
   @include token.flex_column;
   @include token.flex_center;
-  gap: token.$spacing_2xl;
-  padding-top: token.$spacing_2xl;
-  border-top: 1px solid token.$color_border_light;
+  gap: token.$spacing_24;
+  padding-top: token.$spacing_24;
+  border-top: 1px solid token.$color_border_subtle;
 
   &_button {
     width: 100%;
@@ -160,41 +160,52 @@
 }
 
 .recruit_detail_request p {
-  @include token.body_regular;
-  font-size: token.$font_size_md;
-  color: token.$text_normal;
+  @include token.body_medium;
+  font-size: token.$font_size_16;
+  color: token.$color_text_body;
   text-align: center;
 }
 
-@include token.mobile {
+@include token.compact {
   .recruit_detail {
-    padding: token.$spacing_4xl token.$spacing_md;
+    padding: token.$spacing_32 token.$spacing_12;
   }
 
   .recruit_detail_title {
-    font-size: token.$font_size_2xl;
+    font-size: token.$font_size_24;
   }
 
   .recruit_detail_meta {
     flex-direction: column;
     align-items: flex-start;
-    gap: token.$spacing_sm;
+    gap: token.$spacing_8;
+  }
+
+  .chip {
+    height: auto;
+    min-height: 24px;
+    padding: token.$spacing_4 token.$spacing_8;
+    white-space: normal;
   }
 
   .recruit_detail_datebar {
     justify-content: flex-end;
     width: 100%;
+    white-space: normal;
+    height: auto;
+    line-height: 1.75;
   }
 
   .recruit_detail_section h2 {
-    font-size: token.$font_size_lg;
+    font-size: token.$font_size_18;
+    line-height: 1.3;
   }
 
   .recruit_detail_notice {
-    padding: token.$spacing_lg;
+    padding: token.$spacing_16;
   }
 
   .recruit_detail_request p {
-    font-size: token.$font_size_base;
+    font-size: token.$font_size_15;
   }
 }

--- a/src/app/(i18n)/recruit/style.module.scss
+++ b/src/app/(i18n)/recruit/style.module.scss
@@ -1,11 +1,12 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .recruit_page {
   @include token.flex_column;
   align-items: center;
-  width: 70%;
+  width: 100%;
+  max-width: 1100px;
   /* min-height 제거 — PageTransition > * flex: 1로 layout 레벨에서 처리 */
-  padding: token.$spacing_4xl 0 token.$spacing_5xl;
+  padding: token.$spacing_32 token.$spacing_20 36px;
   margin: 0 auto;
 }
 
@@ -14,5 +15,21 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  margin-top: token.$spacing_3xl;
+  margin-top: 28px;
+}
+
+@include token.medium {
+  .recruit_page {
+    padding-inline: token.$spacing_16;
+  }
+}
+
+@include token.compact {
+  .recruit_page {
+    padding: token.$spacing_24 token.$spacing_12 28px;
+  }
+
+  .recruit_page_list {
+    margin-top: token.$spacing_20;
+  }
 }

--- a/src/app/(i18n)/style.module.scss
+++ b/src/app/(i18n)/style.module.scss
@@ -1,4 +1,4 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .main_content {
   width: 100%;
@@ -29,17 +29,19 @@
 %ground_base {
   @include token.flex_column;
   gap: clamp(80px, 10vw, 160px);
-  padding: clamp(60px, 8vw, 120px) 5vw;
+  padding: clamp(60px, 8vw, 120px) clamp(16px, 5vw, 80px);
   width: 100%;
 }
 
 .gradient {
   @extend %ground_base;
+  /* 브랜드 그라데이션 고정 색 — DS 3.1 팔레트에 정확 매칭이 없어 원본 hex 유지.
+     (codemod 이 hex 근접값으로 text_caption #888 등에 매핑하며 색조가 틀어졌던 것 복원) */
   background: linear-gradient(
                   180deg,
-                  token.$color_background_secondary 0%,
-                  token.$text_subtle 48%,
-                  token.$color_background_primary 100%
+                  #fafafa 0%,
+                  #6b7280 48%,
+                  token.$color_base_navy_600 100%
   );
 }
 
@@ -47,9 +49,9 @@
   @extend %ground_base;
   background: linear-gradient(
                   180deg,
-                  token.$color_background_primary 0%,
-                  token.$color_background_primary 15%,
-                  token.$color_background_dark 35%,
-                  token.$color_background_primary 100%
+                  token.$color_base_navy_600 0%,
+                  token.$color_base_navy_600 15%,
+                  #1e293b 35%,
+                  token.$color_base_navy_600 100%
   );
 }

--- a/src/app/error.module.scss
+++ b/src/app/error.module.scss
@@ -1,10 +1,10 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .error_root {
 	@include token.flex_column;
 	@include token.flex_center;
-	gap: token.$spacing_md;
-	padding: token.$spacing_3xl token.$spacing_lg;
+	gap: token.$spacing_12;
+	padding: 28px token.$spacing_16;
 	text-align: center;
 }
 
@@ -14,46 +14,46 @@
 	justify-content: center;
 	width: 64px;
 	height: 64px;
-	border-radius: token.$radius_pill;
-	background: token.$color_error;
-	color: token.$text_inverse;
-	font-size: token.$font_size_2xl;
+	border-radius: 50%;
+	background: token.$color_status_error;
+	color: token.$color_text_inverse;
+	font-size: token.$font_size_24;
 	font-weight: token.$font_weight_bold;
 }
 
 .error_title {
-	font-size: token.$font_size_xl;
+	font-size: token.$font_size_20;
 	font-weight: token.$font_weight_bold;
-	color: token.$text_strong;
+	color: token.$color_text_heading;
 }
 
 .error_desc {
-	font-size: token.$font_size_sm;
-	color: token.$text_subtle;
-	line-height: token.$line_height_relaxed;
+	font-size: token.$font_size_14;
+	color: token.$color_text_caption;
+	line-height: 1.75;
 	white-space: pre-line;
 }
 
 .error_retry_count {
-	font-size: token.$font_size_xs;
-	color: token.$text_subtle;
+	font-size: token.$font_size_12;
+	color: token.$color_text_caption;
 }
 
 .error_max {
-	font-size: token.$font_size_sm;
-	color: token.$color_error;
-	line-height: token.$line_height_relaxed;
+	font-size: token.$font_size_14;
+	color: token.$color_status_error;
+	line-height: 1.75;
 	white-space: pre-line;
 }
 
 .error_actions {
 	display: flex;
-	gap: token.$spacing_sm;
-	margin-top: token.$spacing_sm;
+	gap: token.$spacing_8;
+	margin-top: token.$spacing_8;
 	white-space: nowrap;
 }
 
-@include token.mobile {
+@include token.compact {
 	.error_actions {
 		@include token.flex_column;
 		width: 100%;

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -80,10 +80,10 @@ const GlobalError = ({ error: _error, reset }: { error: Error; reset: () => void
 				{isMaxRetry && <p className={styles.error_max}>{t("retryExceeded")}</p>}
 
 				<div className={styles.error_actions}>
-					<Button variant="primary" onClick={handleRetry} disabled={isCooling || isMaxRetry}>
+					<Button variant="filled" onClick={handleRetry} disabled={isCooling || isMaxRetry}>
 						{retryLabel}
 					</Button>
-					<Button variant="secondary" onClick={handleHome}>
+					<Button variant="tonal" onClick={handleHome}>
 						{t("goHome")}
 					</Button>
 				</div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import "src/app/global.css";
+import "@bigtablet/design-system/style.css";
 import "./global.css";
 import type { Metadata } from "next";
 import { cookies } from "next/headers";

--- a/src/app/not-found.module.scss
+++ b/src/app/not-found.module.scss
@@ -1,10 +1,10 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .root {
 	@include token.flex_column;
 	@include token.flex_center;
-	gap: token.$spacing_md;
-	padding: token.$spacing_3xl token.$spacing_lg;
+	gap: token.$spacing_12;
+	padding: 28px token.$spacing_16;
 	text-align: center;
 }
 
@@ -14,34 +14,34 @@
 	justify-content: center;
 	width: 64px;
 	height: 64px;
-	border-radius: token.$radius_pill;
-	background: token.$text_strong;
-	color: token.$text_inverse;
-	font-size: token.$font_size_lg;
+	border-radius: 50%;
+	background: token.$color_text_heading;
+	color: token.$color_text_inverse;
+	font-size: token.$font_size_18;
 	font-weight: token.$font_weight_bold;
 }
 
 .title {
-	font-size: token.$font_size_xl;
+	font-size: token.$font_size_20;
 	font-weight: token.$font_weight_bold;
-	color: token.$text_strong;
+	color: token.$color_text_heading;
 }
 
 .desc {
-	font-size: token.$font_size_sm;
-	color: token.$text_subtle;
-	line-height: token.$line_height_relaxed;
+	font-size: token.$font_size_14;
+	color: token.$color_text_caption;
+	line-height: 1.75;
 	white-space: pre-line;
 }
 
 .actions {
 	display: flex;
-	gap: token.$spacing_sm;
-	margin-top: token.$spacing_sm;
+	gap: token.$spacing_8;
+	margin-top: token.$spacing_8;
 	white-space: nowrap;
 }
 
-@include token.mobile {
+@include token.compact {
 	.actions {
 		@include token.flex_column;
 		width: 100%;

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -33,10 +33,10 @@ const NotFoundPage = () => {
 				<p className={styles.desc}>{t("notFoundDescription")}</p>
 
 				<div className={styles.actions}>
-					<Button variant="primary" onClick={handleHome}>
+					<Button variant="filled" onClick={handleHome}>
 						{t("goHome")}
 					</Button>
-					<Button variant="secondary" onClick={handleBack}>
+					<Button variant="tonal" onClick={handleBack}>
 						{t("goBack")}
 					</Button>
 				</div>

--- a/src/features/cookie-consent/ui/style.module.scss
+++ b/src/features/cookie-consent/ui/style.module.scss
@@ -1,30 +1,30 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .banner {
 	position: fixed;
-	bottom: token.$spacing_2xl;
-	right: token.$spacing_2xl;
-	z-index: token.$z_modal;
+	bottom: token.$spacing_24;
+	right: token.$spacing_24;
+	z-index: token.$z_level5;
 	width: 360px;
-	background: token.$color_background;
+	background: token.$color_bg_solid;
 	border-radius: token.$radius_lg;
-	box-shadow: token.$shadow_lg;
-	padding: token.$spacing_xl token.$spacing_2xl;
+	box-shadow: token.$elevation_level3;
+	padding: token.$spacing_20 token.$spacing_24;
 	@include token.flex_column;
-	gap: token.$spacing_lg;
+	gap: token.$spacing_16;
 	animation: slide_up token.$transition_base;
 }
 
 .message {
-	@include token.body_regular;
-	color: token.$text_strong;
-	line-height: token.$line_height_relaxed;
+	@include token.body_medium;
+	color: token.$color_text_heading;
+	line-height: 1.75;
 	/* 한글 단어 중간 줄바꿈 방지 */
 	word-break: keep-all;
 	overflow-wrap: break-word;
 
 	a {
-		color: token.$color_primary;
+		color: token.$color_brand_primary;
 		text-decoration: underline;
 		font-weight: token.$font_weight_medium;
 		transition: opacity token.$transition_fast;
@@ -38,18 +38,18 @@
 .actions {
 	display: flex;
 	justify-content: flex-end;
-	gap: token.$spacing_md;
+	gap: token.$spacing_12;
 }
 
 .button_accept {
-	padding: token.$spacing_sm token.$spacing_xl;
+	padding: token.$spacing_8 token.$spacing_20;
 	border-radius: token.$radius_md;
 	border: none;
 	cursor: pointer;
-	@include token.text_sm;
-	font-weight: token.$font_weight_semibold;
-	background: token.$color_background_primary;
-	color: token.$text_inverse;
+	@include token.body_small;
+	font-weight: token.$font_weight_semi_bold;
+	background: token.$color_base_navy_600;
+	color: token.$color_text_inverse;
 	transition:
 		opacity token.$transition_fast,
 		transform token.$transition_fast;
@@ -61,31 +61,31 @@
 }
 
 .button_decline {
-	padding: token.$spacing_sm token.$spacing_xl;
+	padding: token.$spacing_8 token.$spacing_20;
 	border-radius: token.$radius_md;
-	border: 1px solid token.$color_border_light;
+	border: 1px solid token.$color_border_subtle;
 	cursor: pointer;
-	@include token.text_sm;
+	@include token.body_small;
 	font-weight: token.$font_weight_medium;
 	background: transparent;
-	color: token.$text_subtle;
+	color: token.$color_text_caption;
 	transition:
 		background token.$transition_fast,
 		transform token.$transition_fast;
 
 	&:hover {
-		background: token.$color_background_secondary;
+		background: token.$color_bg_solid_dim;
 		transform: translateY(-1px);
 	}
 }
 
-@include token.mobile {
+@include token.compact {
 	.banner {
-		bottom: token.$spacing_md;
-		right: token.$spacing_md;
-		left: token.$spacing_md;
+		bottom: token.$spacing_12;
+		right: token.$spacing_12;
+		left: token.$spacing_12;
 		width: auto;
-		padding: token.$spacing_lg;
+		padding: token.$spacing_16;
 	}
 
 	.actions {

--- a/src/features/recruit/apply/form/ui/form-base.module.scss
+++ b/src/features/recruit/apply/form/ui/form-base.module.scss
@@ -1,47 +1,47 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 /* field */
 .field {
   @include token.flex_column;
-  gap: token.$spacing_sm;
+  gap: token.$spacing_8;
 
   .field_label {
-    @include token.body_medium;
-    font-size: token.$font_size_sm;
-    color: token.$text_strong;
+    @include token.body_medium_medium;
+    font-size: token.$font_size_14;
+    color: token.$color_text_heading;
   }
 }
 
 /* profile / section wrapper */
 .profile {
   @include token.flex_column;
-  gap: token.$spacing_sm;
+  gap: token.$spacing_8;
   width: 100%;
 }
 
 
 /* help / sub / error */
 .help {
-  font-size: token.$font_size_xs;
-  color: token.$text_subtle;
+  font-size: token.$font_size_12;
+  color: token.$color_text_caption;
 }
 
 .sub {
-  font-size: token.$font_size_xs;
-  color: token.$text_subtle;
-  margin-left: token.$spacing_xs;
+  font-size: token.$font_size_12;
+  color: token.$color_text_caption;
+  margin-left: token.$spacing_4;
 }
 
 .error {
-  font-size: token.$font_size_xs;
-  color: token.$color_error;
+  font-size: token.$font_size_12;
+  color: token.$color_status_error;
 }
 
 /* row / stack */
 .row {
   width: 100%;
   display: grid;
-  gap: token.$spacing_sm;
+  gap: token.$spacing_8;
 
   > * {
     min-width: 0;
@@ -51,5 +51,5 @@
 .stack {
   display: grid;
   grid-template-columns: 1fr;
-  gap: token.$spacing_sm;
+  gap: token.$spacing_8;
 }

--- a/src/features/recruit/apply/form/ui/sections/contact/index.tsx
+++ b/src/features/recruit/apply/form/ui/sections/contact/index.tsx
@@ -31,7 +31,7 @@ export const ContactSection = ({ form, email }: Props) => {
 					size="sm"
 					placeholder="홍길동"
 					error={!!errors.name}
-					helperText={errors.name?.message as string}
+					supportingText={errors.name?.message as string}
 					{...register("name")}
 				/>
 			</div>
@@ -51,7 +51,7 @@ export const ContactSection = ({ form, email }: Props) => {
 							onChangeAction={(value) => field.onChange(formatPhone010(value as string))}
 							value={field.value ?? ""}
 							error={!!errors.phoneNumber}
-							helperText={errors.phoneNumber?.message as string}
+							supportingText={errors.phoneNumber?.message as string}
 						/>
 					)}
 				/>
@@ -66,7 +66,7 @@ export const ContactSection = ({ form, email }: Props) => {
 						type="email"
 						placeholder="example@email.com"
 						error={!!errors.email}
-						helperText={errors.email?.message as string}
+						supportingText={errors.email?.message as string}
 						{...register("email")}
 					/>
 					<TextField
@@ -76,7 +76,7 @@ export const ContactSection = ({ form, email }: Props) => {
 						onChangeAction={(value) => email.setAuthCode(value as string)}
 					/>
 					<Button
-						variant="secondary"
+						variant="tonal"
 						onClick={email.send}
 						disabled={email.sendLoading || email.resendSec > 0}
 						size="sm"
@@ -89,7 +89,7 @@ export const ContactSection = ({ form, email }: Props) => {
 								: "전송"}
 					</Button>
 					<Button
-						variant="secondary"
+						variant="tonal"
 						onClick={email.verify}
 						disabled={email.checkLoading}
 						size="sm"
@@ -117,7 +117,7 @@ export const ContactSection = ({ form, email }: Props) => {
 					size="sm"
 					placeholder="서울특별시 중구 세종대로 110"
 					error={!!errors.address}
-					helperText={errors.address?.message as string}
+					supportingText={errors.address?.message as string}
 					{...register("address")}
 				/>
 				<TextField size="sm" placeholder="상세주소" {...register("addressDetail")} />

--- a/src/features/recruit/apply/form/ui/sections/contact/style.module.scss
+++ b/src/features/recruit/apply/form/ui/sections/contact/style.module.scss
@@ -1,10 +1,10 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 @use "../../form-base.module" as base;
 
 .row_email {
   grid-template-columns: minmax(0, 2fr) minmax(120px, 1fr) auto auto;
 
-  @include token.mobile {
+  @include token.compact {
     grid-template-columns: 1fr 1fr;
   }
 }

--- a/src/features/recruit/apply/form/ui/sections/education/index.tsx
+++ b/src/features/recruit/apply/form/ui/sections/education/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Select, TextField } from "@bigtablet/design-system";
+import { Dropdown, TextField } from "@bigtablet/design-system";
 import { useEffect } from "react";
 import { Controller } from "react-hook-form";
 import { ApplyEducationLevel } from "src/entities/recruit/schema/recruit.schema";
@@ -44,12 +44,11 @@ export const EducationSection = ({ form }: Props) => {
 					control={control}
 					name="educationLevel"
 					render={({ field }) => (
-						<Select
+						<Dropdown
 							size="sm"
 							placeholder="최종 학력 선택"
 							value={field.value}
 							onChange={(v) => field.onChange(v)}
-							fullWidth
 							options={[
 								{ value: "GED", label: "검정고시" },
 								{ value: "HIGH_SCHOOL", label: "고등학교 졸업" },
@@ -65,7 +64,7 @@ export const EducationSection = ({ form }: Props) => {
 						size="sm"
 						placeholder="학교명"
 						error={!!errors.schoolName}
-						helperText={errors.schoolName?.message as string}
+						supportingText={errors.schoolName?.message as string}
 						{...register("schoolName")}
 					/>
 				)}
@@ -87,7 +86,7 @@ export const EducationSection = ({ form }: Props) => {
 								onChange={field.onChange}
 								placeholder="YYYY.MM"
 								error={!!errors.admissionYear}
-								helperText={errors.admissionYear?.message as string}
+								supportingText={errors.admissionYear?.message as string}
 							/>
 						)}
 					/>
@@ -105,7 +104,7 @@ export const EducationSection = ({ form }: Props) => {
 									onChange={field.onChange}
 									placeholder="입학년도"
 									error={!!errors.admissionYear}
-									helperText={errors.admissionYear?.message as string}
+									supportingText={errors.admissionYear?.message as string}
 								/>
 							)}
 						/>
@@ -119,7 +118,7 @@ export const EducationSection = ({ form }: Props) => {
 									onChange={field.onChange}
 									placeholder="졸업년도"
 									error={!!errors.graduationEnd}
-									helperText={errors.graduationEnd?.message as string}
+									supportingText={errors.graduationEnd?.message as string}
 								/>
 							)}
 						/>
@@ -129,7 +128,7 @@ export const EducationSection = ({ form }: Props) => {
 						size="sm"
 						placeholder="계열 (학과)"
 						error={!!errors.department}
-						helperText={errors.department?.message as string}
+						supportingText={errors.department?.message as string}
 						{...register("department")}
 					/>
 				</>

--- a/src/features/recruit/apply/form/ui/sections/education/style.module.scss
+++ b/src/features/recruit/apply/form/ui/sections/education/style.module.scss
@@ -1,10 +1,10 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 @use "../../form-base.module" as base;
 
 .row_edu {
   grid-template-columns: 1fr 1fr;
 
-  @include token.tablet {
+  @include token.medium {
     grid-template-columns: 1fr;
   }
 }
@@ -16,7 +16,7 @@
 .row_edu_dates {
   grid-template-columns: repeat(2, 1fr);
 
-  @include token.mobile {
+  @include token.compact {
     grid-template-columns: 1fr;
   }
 }

--- a/src/features/recruit/apply/form/ui/sections/links/index.tsx
+++ b/src/features/recruit/apply/form/ui/sections/links/index.tsx
@@ -27,7 +27,7 @@ export const LinksSection = ({ form }: Props) => {
 					type="url"
 					placeholder="https://github.com/..."
 					error={!!errors.attachment1}
-					helperText={errors.attachment1?.message as string}
+					supportingText={errors.attachment1?.message as string}
 					{...register("attachment1")}
 				/>
 				<TextField
@@ -35,7 +35,7 @@ export const LinksSection = ({ form }: Props) => {
 					type="url"
 					placeholder="https://www.notion.so/..."
 					error={!!errors.attachment2}
-					helperText={errors.attachment2?.message as string}
+					supportingText={errors.attachment2?.message as string}
 					{...register("attachment2")}
 				/>
 				<TextField
@@ -43,7 +43,7 @@ export const LinksSection = ({ form }: Props) => {
 					type="url"
 					placeholder="https://portfolio.site/..."
 					error={!!errors.attachment3}
-					helperText={errors.attachment3?.message as string}
+					supportingText={errors.attachment3?.message as string}
 					{...register("attachment3")}
 				/>
 			</div>

--- a/src/features/recruit/apply/form/ui/sections/military/index.tsx
+++ b/src/features/recruit/apply/form/ui/sections/military/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Select } from "@bigtablet/design-system";
+import { Dropdown } from "@bigtablet/design-system";
 import { Controller } from "react-hook-form";
 import type { ApplyFormProps } from "src/features/recruit/apply/form/ui/type";
 import styles from "../../form-base.module.scss";
@@ -24,12 +24,11 @@ export const MilitarySection = ({ form }: Props) => {
 				control={control}
 				name="military"
 				render={({ field }) => (
-					<Select
+					<Dropdown
 						size="sm"
 						placeholder="병역 사항 선택"
 						value={field.value}
 						onChange={(v) => field.onChange(v)}
-						fullWidth
 						options={[
 							{ value: "", label: "병역 사항 선택", disabled: true },
 							{ value: "COMPLETED", label: "군필" },

--- a/src/features/recruit/apply/form/ui/style.module.scss
+++ b/src/features/recruit/apply/form/ui/style.module.scss
@@ -1,53 +1,74 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .apply_form {
   width: 100%;
   max-width: 880px;
   margin: 0 auto;
-  background: token.$color_background;
-  border: 1px solid token.$color_border;
+  background: token.$color_bg_solid;
+  border: 1px solid token.$color_border_default;
   border-radius: token.$radius_xl;
-  box-shadow: token.$shadow_sm;
-  padding: token.$spacing_4xl token.$spacing_3xl;
+  box-shadow: token.$elevation_level1;
+  padding: token.$spacing_32 28px;
 }
 
 .apply_grid {
   display: flex;
-  gap: token.$spacing_4xl;
+  gap: token.$spacing_32;
 }
 
 .apply_left {
   @include token.flex_column;
-  gap: token.$spacing_xl;
+  gap: token.$spacing_20;
 }
 
 .apply_right {
   @include token.flex_column;
   width: 30%;
-  gap: token.$spacing_lg;
+  gap: token.$spacing_16;
   align-items: flex-start;
   text-align: left;
 }
 
 .apply_submit {
-  margin-top: token.$spacing_xl;
+  margin-top: token.$spacing_20;
 }
 
 .apply_footer {
-  @include token.body_regular;
-  font-size: token.$font_size_xs;
+  @include token.body_medium;
+  font-size: token.$font_size_12;
   text-align: center;
-  color: token.$text_subtle;
-  margin-top: token.$spacing_sm;
+  color: token.$color_text_caption;
+  margin-top: token.$spacing_8;
 
   a {
-    color: token.$color_primary;
+    color: token.$color_brand_primary;
     text-decoration: underline;
   }
 }
 
 .form_error {
-  margin-top: token.$spacing_sm;
-  font-size: token.$font_size_sm;
-  color: token.$color_error;
+  margin-top: token.$spacing_8;
+  font-size: token.$font_size_14;
+  color: token.$color_status_error;
+}
+
+@include token.compact {
+  .apply_form {
+    padding: token.$spacing_24 token.$spacing_12;
+    border-radius: token.$radius_lg;
+  }
+
+  .apply_grid {
+    flex-direction: column;
+    gap: token.$spacing_24;
+  }
+
+  .apply_left {
+    gap: token.$spacing_16;
+  }
+
+  .apply_right {
+    width: 100%;
+    gap: token.$spacing_12;
+  }
 }

--- a/src/features/talent/form/modal/index.tsx
+++ b/src/features/talent/form/modal/index.tsx
@@ -89,7 +89,7 @@ const TalentFormModal = ({ open, onClose }: Props) => {
 								placeholder="이름을 입력하세요"
 								disabled={isFormBusy}
 								error={!!errors.name}
-								helperText={errors.name?.message}
+								supportingText={errors.name?.message}
 								fullWidth
 							/>
 						)}
@@ -115,7 +115,7 @@ const TalentFormModal = ({ open, onClose }: Props) => {
 								placeholder="example@bigtablet.kr"
 								disabled={isFormBusy}
 								error={!!errors.email}
-								helperText={errors.email?.message}
+								supportingText={errors.email?.message}
 								fullWidth
 							/>
 						)}
@@ -135,7 +135,7 @@ const TalentFormModal = ({ open, onClose }: Props) => {
 								placeholder="예: 개발팀"
 								disabled={isFormBusy}
 								error={!!errors.department}
-								helperText={errors.department?.message}
+								supportingText={errors.department?.message}
 								fullWidth
 							/>
 						)}
@@ -159,10 +159,10 @@ const TalentFormModal = ({ open, onClose }: Props) => {
 					/>
 
 					<div className={styles.actions}>
-						<Button variant="secondary" onClick={onClose} disabled={isFormBusy}>
+						<Button variant="tonal" onClick={onClose} disabled={isFormBusy}>
 							취소
 						</Button>
-						<Button variant="primary" type="submit" disabled={isFormBusy}>
+						<Button variant="filled" type="submit" disabled={isFormBusy}>
 							{isPending ? "등록 중..." : "등록하기"}
 						</Button>
 					</div>

--- a/src/features/talent/form/modal/sections/PortfolioSection.tsx
+++ b/src/features/talent/form/modal/sections/PortfolioSection.tsx
@@ -82,7 +82,7 @@ export const PortfolioSection = ({
 							placeholder="https://portfolio.example.com"
 							disabled={isFormBusy}
 							error={!!errors.portfolioUrl}
-							helperText={errors.portfolioUrl?.message}
+							supportingText={errors.portfolioUrl?.message}
 							fullWidth
 						/>
 					)}

--- a/src/features/talent/form/modal/sections/UrlListSection.tsx
+++ b/src/features/talent/form/modal/sections/UrlListSection.tsx
@@ -44,21 +44,27 @@ export const UrlListSection = ({
 								placeholder="예: github.com/user"
 								disabled={isFormBusy}
 								error={!!errors.etcUrl?.[index]}
-								helperText={errors.etcUrl?.[index]?.message}
+								supportingText={errors.etcUrl?.[index]?.message}
 								fullWidth
 							/>
 						)}
 					/>
 
 					{index > 0 && (
-						<Button variant="danger" size="sm" onClick={() => remove(index)} disabled={isFormBusy}>
+						<Button
+							variant="text"
+							danger
+							size="sm"
+							onClick={() => remove(index)}
+							disabled={isFormBusy}
+						>
 							삭제
 						</Button>
 					)}
 				</div>
 			))}
 
-			<Button variant="secondary" size="sm" onClick={() => append("")} disabled={isFormBusy}>
+			<Button variant="tonal" size="sm" onClick={() => append("")} disabled={isFormBusy}>
 				+ URL 추가
 			</Button>
 		</div>

--- a/src/features/talent/form/modal/style.module.scss
+++ b/src/features/talent/form/modal/style.module.scss
@@ -1,10 +1,10 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .modal_overlay {
   position: fixed;
   inset: 0;
-  background: token.$color_overlay;
-  z-index: token.$z_modal; /* DS: z_toast > z_modal이므로 toast가 모달 위에 표시됨 */
+  background: token.$color_bg_overlay;
+  z-index: token.$z_level5; /* DS: z_toast > z_modal이므로 toast가 모달 위에 표시됨 */
   @include token.flex_center;
   backdrop-filter: blur(6px);
 }
@@ -13,60 +13,60 @@
   width: 420px;
   max-height: 80vh;
   overflow-y: auto;
-  background: token.$color_background;
+  background: token.$color_bg_solid;
   border-radius: token.$radius_lg;
-  box-shadow: token.$shadow_lg;
-  padding: token.$spacing_3xl;
+  box-shadow: token.$elevation_level3;
+  padding: 28px;
   animation: fade_in token.$transition_base;
 
   h2 {
-    @include token.heading_3;
-    color: token.$text_strong;
-    margin-bottom: token.$spacing_2xl;
+    @include token.heading_small_bold;
+    color: token.$color_text_heading;
+    margin-bottom: token.$spacing_24;
   }
 }
 
 .form {
   @include token.flex_column;
-  gap: token.$spacing_xl;
+  gap: token.$spacing_20;
 }
 
 .portfolio {
   @include token.flex_column;
-  gap: token.$spacing_sm;
-  @include token.body_regular;
-  color: token.$text_strong;
+  gap: token.$spacing_8;
+  @include token.body_medium;
+  color: token.$color_text_heading;
 }
 
 .portfolio_header {
   @include token.flex_between;
   align-items: center;
-  gap: token.$spacing_md;
+  gap: token.$spacing_12;
 
   span {
-    @include token.body_medium;
-    color: token.$text_strong;
+    @include token.body_medium_medium;
+    color: token.$color_text_heading;
   }
 }
 
 .portfolio_toggle {
   display: inline-flex;
   align-items: center;
-  gap: token.$spacing_xs;
-  padding: token.$spacing_xs;
+  gap: token.$spacing_4;
+  padding: token.$spacing_4;
   border-radius: token.$radius_full;
-  background: token.$color_background_secondary;
-  border: 1px solid token.$color_border_light;
+  background: token.$color_bg_solid_dim;
+  border: 1px solid token.$color_border_subtle;
 }
 
 .portfolio_toggle_button {
-  padding: token.$spacing_xs token.$spacing_md;
+  padding: token.$spacing_4 token.$spacing_12;
   border-radius: token.$radius_full;
   background: transparent;
   border: none;
   cursor: pointer;
-  @include token.text_sm;
-  color: token.$text_subtle;
+  @include token.body_small;
+  color: token.$color_text_caption;
   transition: token.$transition_base;
 
   &:disabled {
@@ -75,19 +75,19 @@
   }
 
   &:hover:not(:disabled) {
-    background: token.$color_background_secondary;
+    background: token.$color_bg_solid_dim;
   }
 }
 
 .portfolio_toggle_active {
-  padding: token.$spacing_xs token.$spacing_md;
+  padding: token.$spacing_4 token.$spacing_12;
   border-radius: token.$radius_full;
   border: none;
   cursor: pointer;
-  @include token.text_sm;
+  @include token.body_small;
   transition: token.$transition_base;
-  background: token.$color_background_secondary;
-  color: token.$color_primary;
+  background: token.$color_bg_solid_dim;
+  color: token.$color_brand_primary;
 
   &:disabled {
     opacity: 0.5;
@@ -96,41 +96,41 @@
 }
 
 .portfolio_file {
-  margin-top: token.$spacing_sm;
+  margin-top: token.$spacing_8;
   @include token.flex_column;
-  gap: token.$spacing_xs;
+  gap: token.$spacing_4;
 }
 
 .helper {
-  @include token.text_sm;
-  color: token.$text_subtle;
+  @include token.body_small;
+  color: token.$color_text_caption;
 }
 
 .portfolio_error {
-  @include token.text_sm;
-  color: token.$color_error;
+  @include token.body_small;
+  color: token.$color_status_error;
 }
 
 .urls {
   @include token.flex_column;
-  gap: token.$spacing_md;
+  gap: token.$spacing_12;
 
   span {
-    @include token.text_sm;
-    color: token.$text_subtle;
+    @include token.body_small;
+    color: token.$color_text_caption;
   }
 
   .url_row {
     @include token.flex_column;
-    gap: token.$spacing_xs;
+    gap: token.$spacing_4;
     align-items: flex-end;
   }
 }
 
 .actions {
   @include token.flex_right;
-  gap: token.$spacing_lg;
-  margin-top: token.$spacing_xl;
+  gap: token.$spacing_16;
+  margin-top: token.$spacing_20;
 }
 
 @keyframes fade_in {

--- a/src/shared/styles/_ds-token.scss
+++ b/src/shared/styles/_ds-token.scss
@@ -1,0 +1,91 @@
+// =============================================================================
+// DS 3.1 토큰 진입점 (로컬 shim)
+// -----------------------------------------------------------------------------
+// 문제: @bigtablet/design-system 의 scss/token 은 colors/elevation 서브모듈을
+//   @forward 하는데, 두 모듈은 top-level 에 `:root { --bt-* }` / `[data-theme="dark"]`
+//   CSS 를 emit 한다. CSS Modules(*.module.scss)는 모듈마다 별도 컴파일되어 매번
+//   재emit → (1) 48× 중복, (2) `[data-theme="dark"]` 가 "not pure" 빌드 에러.
+//   DS 3.1.1 에는 emit 을 끄는 !default 플래그가 없고, exports 가 서브패스를
+//   막아 colors 만 선택 제외할 수도 없다.
+//
+// 해법: CSS 를 emit 하지 않는 서브모듈(spacing/typography/... — 주석뿐인 layout/
+//   motion 포함)은 그대로 @forward 해 멤버를 노출하고, CSS 를 emit 하는
+//   colors/elevation 의 멤버만 var(--bt-*) 별칭으로 재선언한다(선언은 CSS 출력 0).
+//   실제 :root / [data-theme] 정의는 layout.tsx 의
+//   `import "@bigtablet/design-system/style.css"` 가 전역에서 한 번 공급한다.
+//
+// 서브모듈 직접 import 는 next.config.mjs sassOptions.includePaths 에 추가한
+//   DS dist/styles 경로(심링크)로 해석된다.
+// =============================================================================
+
+// ── CSS 를 emit 하지 않는 모듈 — 멤버 그대로 forward ─────────────────────────
+@forward "spacing";
+@forward "typography";
+@forward "radius";
+@forward "breakpoints";
+@forward "opacity";
+@forward "z-index";
+@forward "border-width";
+@forward "layout"; // top-level 은 주석뿐 (flex_*/hover_*/glass_* 믹스인)
+@forward "motion"; // top-level 은 주석뿐 ($transition_*/$ease_* 변수)
+
+// ── colors: :root emit 회피 위해 시맨틱 토큰을 var 별칭으로 재선언 ───────────
+// (이름/값은 DS colors/_index.scss 의 `$color_*: var(--bt-color-*)` 와 1:1 동일)
+$color_brand_primary: var(--bt-color-brand-primary);
+$color_brand_on_primary: var(--bt-color-brand-on-primary);
+$color_brand_primary_container: var(--bt-color-brand-primary-container);
+
+$color_text_heading: var(--bt-color-text-heading);
+$color_text_body: var(--bt-color-text-body);
+$color_text_caption: var(--bt-color-text-caption);
+$color_text_brand: var(--bt-color-text-brand);
+$color_text_inverse: var(--bt-color-text-inverse);
+$color_text_disabled: var(--bt-color-text-disabled);
+
+$color_bg_solid: var(--bt-color-bg-solid);
+$color_bg_solid_dim: var(--bt-color-bg-solid-dim);
+$color_bg_additive: var(--bt-color-bg-additive);
+$color_bg_disabled: var(--bt-color-bg-disabled);
+$color_bg_overlay: var(--bt-color-bg-overlay);
+$color_bg_inverse_surface: var(--bt-color-bg-inverse-surface);
+
+$color_border_default: var(--bt-color-border-default);
+$color_border_hover: var(--bt-color-border-hover);
+$color_border_subtle: var(--bt-color-border-subtle);
+$color_border_focus: var(--bt-color-border-focus);
+$color_border_disabled: var(--bt-color-border-disabled);
+
+$color_accent_default: var(--bt-color-accent-default);
+$color_accent_strong: var(--bt-color-accent-strong);
+$color_accent_light: var(--bt-color-accent-light);
+$color_accent_muted: var(--bt-color-accent-muted);
+$color_accent_subtle: var(--bt-color-accent-subtle);
+$color_accent_on_surface: var(--bt-color-accent-on-surface);
+
+$color_state_hover_on_light: var(--bt-color-state-hover-on-light);
+$color_state_pressed_on_light: var(--bt-color-state-pressed-on-light);
+$color_state_focus_on_light: var(--bt-color-state-focus-on-light);
+$color_state_hover_on_dark: var(--bt-color-state-hover-on-dark);
+$color_state_pressed_on_dark: var(--bt-color-state-pressed-on-dark);
+$color_state_focus_on_dark: var(--bt-color-state-focus-on-dark);
+
+$color_status_error: var(--bt-color-status-error);
+$color_status_success: var(--bt-color-status-success);
+$color_status_warning: var(--bt-color-status-warning);
+$color_status_info: var(--bt-color-status-info);
+
+// ── raw 팔레트: colors 를 @forward 하지 않으므로(=:root emit 회피) 코드에서
+//    직접 쓰는 $color_base_* 만 원본 값으로 재선언 (값은 DS 와 1:1 동일) ──────
+$color_base_navy_600: #47555e;
+$color_base_navy_900: #1f2630;
+$color_base_alpha_black_38: rgba(26, 26, 26, 0.38);
+$color_base_alpha_black_50: rgba(0, 0, 0, 0.5);
+$color_base_alpha_white_8: rgba(255, 255, 255, 0.08);
+$color_base_alpha_white_12: rgba(255, 255, 255, 0.12);
+
+// ── elevation: 동일 사유로 var 별칭 재선언 ──────────────────────────────────
+$elevation_level1: var(--bt-elevation-level1);
+$elevation_level2: var(--bt-elevation-level2);
+$elevation_level3: var(--bt-elevation-level3);
+$elevation_level4: var(--bt-elevation-level4);
+$elevation_level5: var(--bt-elevation-level5);

--- a/src/shared/ui/back-link/style.module.scss
+++ b/src/shared/ui/back-link/style.module.scss
@@ -1,23 +1,23 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .back_link {
-	@include token.body_medium;
+	@include token.body_medium_medium;
 	appearance: none;
 	font: inherit;
 	cursor: pointer;
 	display: inline-flex;
 	align-items: center;
 	align-self: flex-start;
-	gap: token.$spacing_xs;
-	font-size: token.$font_size_sm;
-	color: token.$text_strong;
-	background: token.$color_background;
-	padding: token.$spacing_sm token.$spacing_md;
+	gap: token.$spacing_4;
+	font-size: token.$font_size_14;
+	color: token.$color_text_heading;
+	background: token.$color_bg_solid;
+	padding: token.$spacing_8 token.$spacing_12;
 	border-radius: token.$radius_md;
-	border: 1px solid token.$color_border;
+	border: 1px solid token.$color_border_default;
 	transition: background token.$transition_base;
 
 	&:hover {
-		background: token.$color_background_secondary;
+		background: token.$color_bg_solid_dim;
 	}
 }

--- a/src/shared/ui/error-fallback/index.tsx
+++ b/src/shared/ui/error-fallback/index.tsx
@@ -25,7 +25,7 @@ const ErrorFallback = ({ reset, backHref, backLabel }: ErrorFallbackProps) => {
 			<p className={styles.error_fallback_desc}>{t("description")}</p>
 
 			<div className={styles.error_fallback_actions}>
-				<Button variant="primary" onClick={() => reset()}>
+				<Button variant="filled" onClick={() => reset()}>
 					{t("retry")}
 				</Button>
 

--- a/src/shared/ui/error-fallback/style.module.scss
+++ b/src/shared/ui/error-fallback/style.module.scss
@@ -1,4 +1,4 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .error_fallback {
     display: flex;
@@ -6,22 +6,22 @@
     align-items: center;
     justify-content: center;
     min-height: 50vh;
-    padding: token.$spacing_3xl token.$spacing_xl;
+    padding: 28px token.$spacing_20;
     text-align: center;
 }
 
 .error_fallback_title {
-    font-size: token.$font_size_2xl;
+    font-size: token.$font_size_24;
     font-weight: token.$font_weight_bold;
-    color: token.$text_strong;
-    margin-bottom: token.$spacing_md;
+    color: token.$color_text_heading;
+    margin-bottom: token.$spacing_12;
 }
 
 .error_fallback_desc {
-    font-size: token.$font_size_md;
-    color: token.$text_normal;
-    line-height: token.$line_height_normal;
-    margin-bottom: token.$spacing_2xl;
+    font-size: token.$font_size_16;
+    color: token.$color_text_body;
+    line-height: 1.5;
+    margin-bottom: token.$spacing_24;
     white-space: pre-line;
 }
 
@@ -29,16 +29,16 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: token.$spacing_lg;
+    gap: token.$spacing_16;
 }
 
 .error_fallback_back {
-    font-size: token.$font_size_sm;
-    color: token.$text_subtle;
+    font-size: token.$font_size_14;
+    color: token.$color_text_caption;
     text-decoration: underline;
     transition: color token.$transition_base;
 
     &:hover {
-        color: token.$text_strong;
+        color: token.$color_text_heading;
     }
 }

--- a/src/shared/ui/footer/index.tsx
+++ b/src/shared/ui/footer/index.tsx
@@ -1,16 +1,20 @@
+"use client";
+
 import Link from "next/link";
-import { getTranslations } from "next-intl/server";
+import { useTranslations } from "next-intl";
 import styles from "./style.module.scss";
 
 /**
  * @component Footer
  *
  * @description
- * 사이트 공통 푸터. 클라이언트 이벤트 없으므로 server component 로 렌더 — hydration JS 미포함.
- * 번역은 `getTranslations` 로 서버에서 직접 가져옴.
+ * 사이트 공통 푸터. client 컴포넌트 — server layout(서버 트리)뿐 아니라
+ * "use client" 인 Template(error/not-found 페이지) 안에서도 렌더되어야 하므로
+ * `useTranslations`(client hook) 사용. 부모의 NextIntlClientProvider 에 footer 메시지 포함.
+ * (이전엔 async server + getTranslations 라 client 트리에서 렌더 시 크래시했음)
  */
-const Footer = async () => {
-	const t = await getTranslations("footer");
+const Footer = () => {
+	const t = useTranslations("footer");
 
 	return (
 		<footer className={styles.footer}>

--- a/src/shared/ui/footer/style.module.scss
+++ b/src/shared/ui/footer/style.module.scss
@@ -1,61 +1,61 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .footer {
-	background: token.$color_background_primary;
-	color: token.$text_inverse;
+	background: token.$color_base_navy_600;
+	color: token.$color_text_inverse;
 	width: 100%;
 }
 
 .footer_inner {
 	max-width: 1200px;
 	margin: 0 auto;
-	padding: token.$spacing_2xl token.$spacing_2xl token.$spacing_xl;
+	padding: token.$spacing_24 token.$spacing_24 token.$spacing_20;
 	display: grid;
 	grid-template-columns: 1fr auto;
-	gap: token.$spacing_2xl;
+	gap: token.$spacing_24;
 }
 
 .footer_left {
 	@include token.flex_column;
-	gap: token.$spacing_sm;
+	gap: token.$spacing_8;
 	max-width: 640px;
 
 	p {
-		font-size: token.$font_size_sm;
-		line-height: token.$line_height_relaxed;
+		font-size: token.$font_size_14;
+		line-height: 1.75;
 		color: rgba(255, 255, 255, 0.5);
 	}
 }
 
 .footer_brand {
-	font-size: token.$font_size_lg;
-	font-weight: token.$font_weight_semibold;
-	color: token.$text_inverse;
+	font-size: token.$font_size_18;
+	font-weight: token.$font_weight_semi_bold;
+	color: token.$color_text_inverse;
 	letter-spacing: token.$letter_spacing_tight;
 }
 
 .footer_addr {
 	font-style: normal;
-	font-size: token.$font_size_sm;
-	line-height: token.$line_height_relaxed;
+	font-size: token.$font_size_14;
+	line-height: 1.75;
 	color: rgba(255, 255, 255, 0.7);
 }
 
 .footer_links {
-	margin-top: token.$spacing_sm;
+	margin-top: token.$spacing_8;
 	display: flex;
 	flex-wrap: wrap;
-	gap: token.$spacing_xl;
+	gap: token.$spacing_20;
 
 	a {
-		font-size: token.$font_size_sm;
+		font-size: token.$font_size_14;
 		font-weight: token.$font_weight_medium;
 		color: rgba(255, 255, 255, 0.8);
 		text-decoration: none;
 		transition: color token.$transition_fast;
 
 		&:hover {
-			color: token.$text_inverse;
+			color: token.$color_text_inverse;
 		}
 	}
 }
@@ -64,7 +64,7 @@
 	list-style: none;
 	display: flex;
 	align-items: flex-start;
-	gap: token.$spacing_md;
+	gap: token.$spacing_12;
 	padding: 0;
 	margin: 0;
 }
@@ -85,28 +85,28 @@
 	width: 40px;
 	height: 40px;
 	border-radius: token.$radius_lg;
-	background: token.$color_glass_light;
+	background: token.$color_base_alpha_white_8;
 	display: grid;
 	place-items: center;
-	color: token.$text_inverse;
+	color: token.$color_text_inverse;
 	transition:
 		transform token.$transition_fast,
 		background token.$transition_fast;
 
 	&:hover {
 		transform: translateY(-2px);
-		background: token.$color_glass_border;
+		background: token.$color_base_alpha_white_12;
 	}
 }
 
-@include token.mobile {
+@include token.compact {
 	.footer_inner {
 		grid-template-columns: 1fr;
-		gap: token.$spacing_2xl;
-		padding: token.$spacing_3xl token.$spacing_lg token.$spacing_2xl;
+		gap: token.$spacing_24;
+		padding: 28px token.$spacing_16 token.$spacing_24;
 	}
 
 	.footer_social {
-		margin-top: token.$spacing_sm;
+		margin-top: token.$spacing_8;
 	}
 }

--- a/src/shared/ui/form/date/index.tsx
+++ b/src/shared/ui/form/date/index.tsx
@@ -14,7 +14,7 @@ type Props = {
 	placeholder?: string;
 	disabled?: boolean;
 	error?: boolean;
-	helperText?: string;
+	supportingText?: string;
 };
 
 const toDate = (value?: string) => {
@@ -53,7 +53,7 @@ const MonthPickerField = ({
 	placeholder,
 	disabled,
 	error,
-	helperText,
+	supportingText,
 }: Props) => {
 	return (
 		<div className={styles.month_picker}>
@@ -71,7 +71,7 @@ const MonthPickerField = ({
 						placeholder={placeholder ?? "YYYY.MM"}
 						size="sm"
 						error={error}
-						helperText={helperText}
+						supportingText={supportingText}
 					/>
 				}
 				className={styles.month_picker_input}

--- a/src/shared/ui/form/date/style.module.scss
+++ b/src/shared/ui/form/date/style.module.scss
@@ -1,16 +1,16 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .month_picker {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: token.$spacing_xs;
+  gap: token.$spacing_4;
 }
 
 .month_picker_label {
-  @include token.body_medium;
-  font-size: token.$font_size_sm;
-  color: token.$text_strong;
+  @include token.body_medium_medium;
+  font-size: token.$font_size_14;
+  color: token.$color_text_heading;
 }
 
 .month_picker_input {
@@ -20,48 +20,48 @@
 .month_picker_popup {
   font-family: inherit;
   border-radius: token.$radius_lg;
-  border: 1px solid token.$color_border;
-  box-shadow: token.$shadow_sm;
-  background: token.$color_background;
-  padding: token.$spacing_sm;
+  border: 1px solid token.$color_border_default;
+  box-shadow: token.$elevation_level1;
+  background: token.$color_bg_solid;
+  padding: token.$spacing_8;
 
   .react-datepicker__header {
-    background: token.$color_background;
-    border-bottom: 1px solid token.$color_border;
-    padding-block: token.$spacing_xs;
+    background: token.$color_bg_solid;
+    border-bottom: 1px solid token.$color_border_default;
+    padding-block: token.$spacing_4;
   }
 
   .react-datepicker__current-month,
   .react-datepicker__month-read-view--selected-month,
   .react-datepicker__year-read-view--selected-year {
-    @include token.body_medium;
-    font-size: token.$font_size_sm;
-    color: token.$text_strong;
+    @include token.body_medium_medium;
+    font-size: token.$font_size_14;
+    color: token.$color_text_heading;
   }
 
   .react-datepicker__month {
-    margin: token.$spacing_sm;
+    margin: token.$spacing_8;
   }
 
   .react-datepicker__month-text {
-    @include token.body_regular;
-    font-size: token.$font_size_sm;
-    color: token.$text_normal;
+    @include token.body_medium;
+    font-size: token.$font_size_14;
+    color: token.$color_text_body;
     border-radius: token.$radius_md;
-    padding: token.$spacing_xs token.$spacing_sm;
+    padding: token.$spacing_4 token.$spacing_8;
 
     &--selected,
     &--keyboard-selected {
-      background: token.$color_primary;
-      color: token.$text_inverse;
+      background: token.$color_brand_primary;
+      color: token.$color_text_inverse;
     }
 
     &:hover {
-      background: token.$color_background_secondary;
+      background: token.$color_bg_solid_dim;
     }
   }
 
   .react-datepicker__navigation {
-    top: token.$spacing_xs;
+    top: token.$spacing_4;
   }
 }

--- a/src/shared/ui/form/file/style.module.scss
+++ b/src/shared/ui/form/file/style.module.scss
@@ -1,15 +1,15 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .file {
   display: flex;
-  gap: token.$spacing_sm;
+  gap: token.$spacing_8;
   align-items: center;
   position: relative;
 }
 
 .file_control {
   display: flex;
-  gap: token.$spacing_sm;
+  gap: token.$spacing_8;
   align-items: center;
   position: relative;
 }
@@ -22,23 +22,23 @@
 }
 
 .file_label {
-  border: 1px solid token.$color_border;
+  border: 1px solid token.$color_border_default;
   border-radius: token.$radius_md;
-  background: token.$color_background;
-  padding: token.$spacing_sm token.$spacing_lg;
-  color: token.$text_normal;
-  font-size: token.$font_size_sm;
+  background: token.$color_bg_solid;
+  padding: token.$spacing_8 token.$spacing_16;
+  color: token.$color_text_body;
+  font-size: token.$font_size_14;
   transition: border-color token.$transition_base, background token.$transition_base;
   cursor: pointer;
 
   &:hover {
-    border-color: token.$color_border_light;
+    border-color: token.$color_border_subtle;
   }
 }
 
 .file_name {
-  font-size: token.$font_size_sm;
-  color: token.$text_subtle;
+  font-size: token.$font_size_14;
+  color: token.$color_text_caption;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -52,7 +52,7 @@
 .file_column {
   @include token.flex_column;
   align-items: flex-start;
-  gap: token.$spacing_sm;
+  gap: token.$spacing_8;
 }
 
 .file_column .file_control {
@@ -64,8 +64,8 @@
   max-width: 260px;
   aspect-ratio: 3 / 4;
   border-radius: token.$radius_xl;
-  border: 1px dashed token.$color_border;
-  background: token.$color_background_secondary;
+  border: 1px dashed token.$color_border_default;
+  background: token.$color_bg_solid_dim;
   overflow: hidden;
   display: grid;
   place-items: center;

--- a/src/shared/ui/header/style.module.scss
+++ b/src/shared/ui/header/style.module.scss
@@ -1,5 +1,5 @@
 @use "sass:color";
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 $header_height: 80px;
 $header_height_mobile: 64px;
@@ -7,39 +7,39 @@ $header_height_mobile: 64px;
 .header {
 	position: sticky;
 	top: 0;
-	z-index: token.$z_modal;
+	z-index: token.$z_level5;
 	width: 100%;
 	height: $header_height;
-	background: token.$color_background;
-	color: token.$text_normal;
+	background: token.$color_bg_solid;
+	color: token.$color_text_body;
 	transition: background-color token.$transition_base, box-shadow token.$transition_base;
 
-	@include token.mobile {
+	@include token.compact {
 		height: $header_height_mobile;
 	}
 }
 
 .scrolled {
-	box-shadow: token.$shadow_md;
+	box-shadow: token.$elevation_level2;
 }
 
 .inner {
 	@include token.flex_between;
 	height: 100%;
-	padding-inline: clamp(token.$spacing_lg, 6vw, token.$spacing_4xl);
+	padding-inline: clamp(token.$spacing_16, 6vw, token.$spacing_32);
 	max-width: 1440px;
 	margin: 0 auto;
 	transition: transform token.$transition_base;
 
-	@include token.mobile {
-		padding-inline: token.$spacing_lg;
+	@include token.compact {
+		padding-inline: token.$spacing_16;
 	}
 }
 
 .logo {
 	vertical-align: middle;
 
-	@include token.mobile {
+	@include token.compact {
 		width: 100px;
 		height: auto;
 	}
@@ -55,39 +55,39 @@ $header_height_mobile: 64px;
 	border: none;
 	border-radius: token.$radius_md;
 	background: transparent;
-	color: token.$text_normal;
+	color: token.$color_text_body;
 	cursor: pointer;
 	transition: background-color token.$transition_fast;
 	-webkit-tap-highlight-color: transparent;
 
 	&:hover {
-		background: token.$color_background_secondary;
+		background: token.$color_bg_solid_dim;
 	}
 
 	&:active {
-		background: token.$color_background_muted;
+		background: token.$color_bg_solid_dim;
 	}
 
-	@include token.mobile {
+	@include token.compact {
 		display: flex;
 		position: relative;
-		z-index: calc(token.$z_modal + 2);
+		z-index: calc(token.$z_level5 + 2);
 	}
 }
 
 .nav {
 	display: flex;
 	align-items: center;
-	gap: clamp(token.$spacing_sm, 3vw, token.$spacing_xl);
+	gap: clamp(token.$spacing_8, 3vw, token.$spacing_20);
 
-	@include token.body_medium;
+	@include token.body_medium_medium;
 
 	a {
-		@include token.body_medium;
-		font-weight: token.$font_weight_semibold;
+		@include token.body_medium_medium;
+		font-weight: token.$font_weight_semi_bold;
 		position: relative;
-		padding: token.$spacing_xs 2px;
-		color: token.$text_normal;
+		padding: token.$spacing_4 2px;
+		color: token.$color_text_body;
 		transition: color token.$transition_fast;
 
 		&::after {
@@ -105,7 +105,7 @@ $header_height_mobile: 64px;
 		}
 
 		&:hover {
-			color: token.$text_strong;
+			color: token.$color_text_heading;
 		}
 
 		&:hover::after {
@@ -114,27 +114,27 @@ $header_height_mobile: 64px;
 		}
 	}
 
-	@include token.mobile {
+	@include token.compact {
 		position: fixed;
 		top: 0;
 		right: 0;
 		width: min(320px, 85vw);
 		height: 100dvh;
-		padding: calc($header_height_mobile + token.$spacing_2xl) token.$spacing_2xl token.$spacing_2xl;
+		padding: calc($header_height_mobile + token.$spacing_24) token.$spacing_24 token.$spacing_24;
 		flex-direction: column;
 		align-items: stretch;
 		gap: 0;
-		background: token.$color_background;
-		box-shadow: token.$shadow_lg;
+		background: token.$color_bg_solid;
+		box-shadow: token.$elevation_level3;
 		transform: translateX(100%);
 		transition: transform token.$transition_slide;
-		z-index: calc(token.$z_modal + 1);
+		z-index: calc(token.$z_level5 + 1);
 		overflow-y: auto;
 
 		a {
-			padding: token.$spacing_lg 0;
-			font-size: token.$font_size_lg;
-			border-bottom: 1px solid token.$color_border_light;
+			padding: token.$spacing_16 0;
+			font-size: token.$font_size_18;
+			border-bottom: 1px solid token.$color_border_subtle;
 
 			&::after {
 				display: none;
@@ -148,17 +148,17 @@ $header_height_mobile: 64px;
 }
 
 .nav_open {
-	@include token.mobile {
+	@include token.compact {
 		transform: translateX(0);
 	}
 }
 
 .locale_switch {
-	margin-left: clamp(token.$spacing_sm, 2vw, token.$spacing_md);
-	padding: token.$spacing_xs token.$spacing_md;
+	margin-left: clamp(token.$spacing_8, 2vw, token.$spacing_12);
+	padding: token.$spacing_4 token.$spacing_12;
 	border-radius: token.$radius_md;
-	border: 1px solid token.$color_border;
-	background: token.$color_background_secondary;
+	border: 1px solid token.$color_border_default;
+	background: token.$color_bg_solid_dim;
 	cursor: pointer;
 	transition:
 		transform token.$transition_fast,
@@ -166,7 +166,7 @@ $header_height_mobile: 64px;
 		border-color token.$transition_base;
 
 	&:hover {
-		background: token.$color_background_muted;
+		background: token.$color_bg_solid_dim;
 		transform: translateY(-1px);
 	}
 
@@ -174,11 +174,11 @@ $header_height_mobile: 64px;
 		transform: translateY(0);
 	}
 
-	@include token.mobile {
+	@include token.compact {
 		margin-left: 0;
-		margin-top: token.$spacing_2xl;
-		padding: token.$spacing_md token.$spacing_lg;
-		font-size: token.$font_size_base;
+		margin-top: token.$spacing_24;
+		padding: token.$spacing_12 token.$spacing_16;
+		font-size: token.$font_size_15;
 		text-align: center;
 	}
 }
@@ -186,12 +186,12 @@ $header_height_mobile: 64px;
 .overlay {
 	display: none;
 
-	@include token.mobile {
+	@include token.compact {
 		display: block;
 		position: fixed;
 		inset: 0;
-		background: token.$color_overlay;
-		z-index: token.$z_modal;
+		background: token.$color_bg_overlay;
+		z-index: token.$z_level5;
 		animation: fade_in 0.2s ease-out;
 	}
 }

--- a/src/shared/ui/image-thumb/style.module.scss
+++ b/src/shared/ui/image-thumb/style.module.scss
@@ -1,4 +1,4 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .thumb {
   position: relative;
@@ -7,7 +7,7 @@
 
 /* 로딩 중 — base 회색 위에 밝은 sweep band가 좌→우로 흐름 */
 .thumb_loading {
-  background-color: token.$color_background_muted;
+  background-color: token.$color_bg_solid_dim;
   background-image: linear-gradient(
     100deg,
     transparent 20%,
@@ -44,14 +44,14 @@
 .thumb_fallback {
   background: linear-gradient(
     135deg,
-    token.$color_background_secondary 0%,
-    token.$color_background 100%
+    token.$color_bg_solid_dim 0%,
+    token.$color_bg_solid 100%
   );
   display: flex;
   align-items: center;
   justify-content: center;
-  color: token.$text_subtle;
-  font-size: token.$font_size_sm;
+  color: token.$color_text_caption;
+  font-size: token.$font_size_14;
   animation: none;
 }
 

--- a/src/shared/ui/route-loading/index.tsx
+++ b/src/shared/ui/route-loading/index.tsx
@@ -28,6 +28,11 @@ const RouteLoading = () => {
 		}
 	}, []);
 
+	const clearLoading = useCallback(() => {
+		cancelShowTimer();
+		setIsLoading(false);
+	}, [cancelShowTimer]);
+
 	const handleStart = useCallback(() => {
 		cancelShowTimer();
 		showTimerRef.current = setTimeout(() => {
@@ -39,9 +44,21 @@ const RouteLoading = () => {
 	useEffect(() => {
 		void pathname;
 		void searchParams;
-		cancelShowTimer();
-		setIsLoading(false);
-	}, [pathname, searchParams, cancelShowTimer]);
+		clearLoading();
+	}, [pathname, searchParams, clearLoading]);
+
+	/**
+	 * bfcache(뒤로/앞으로가기 복원) 케이스: 복원 시 pathname effect가 재실행되지
+	 * 않아 로딩바가 fallback(LOADING_TIMEOUT)까지 떠 있었음. pageshow.persisted로
+	 * 복원을 즉시 감지해 로딩을 해제한다.
+	 */
+	useEffect(() => {
+		const handlePageShow = (event: PageTransitionEvent) => {
+			if (event.persisted) clearLoading();
+		};
+		window.addEventListener("pageshow", handlePageShow);
+		return () => window.removeEventListener("pageshow", handlePageShow);
+	}, [clearLoading]);
 
 	/**
 	 * 안전장치: bfcache 복원 등으로 pathname effect가 재실행되지 않는 경우

--- a/src/shared/ui/skeleton/card/style.module.scss
+++ b/src/shared/ui/skeleton/card/style.module.scss
@@ -1,30 +1,30 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .card_skeleton {
   @include token.flex_column;
-  border: 1px solid token.$color_border;
+  border: 1px solid token.$color_border_default;
   border-radius: token.$radius_lg;
   overflow: hidden;
-  background: token.$color_background;
+  background: token.$color_bg_solid;
   animation: card_skeleton_pulse 1.5s ease-in-out infinite;
 }
 
 .card_skeleton_thumb {
   width: 100%;
   aspect-ratio: 4 / 3;
-  background: token.$color_background_secondary;
+  background: token.$color_bg_solid_dim;
 }
 
 .card_skeleton_text {
-  padding: token.$spacing_md;
+  padding: token.$spacing_12;
   display: flex;
   flex-direction: column;
-  gap: token.$spacing_sm;
+  gap: token.$spacing_8;
 }
 
 .card_skeleton_line {
   height: 0.75rem;
-  background: token.$color_background_secondary;
+  background: token.$color_bg_solid_dim;
   border-radius: token.$radius_sm;
 }
 

--- a/src/shared/ui/skeleton/detail/style.module.scss
+++ b/src/shared/ui/skeleton/detail/style.module.scss
@@ -1,15 +1,15 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .detail_skeleton {
   @include token.flex_column;
   width: 100%;
-  gap: token.$spacing_md;
+  gap: token.$spacing_12;
   animation: detail_skeleton_pulse 1.5s ease-in-out infinite;
 }
 
 .detail_skeleton_line {
   height: 1rem;
-  background: token.$color_background_secondary;
+  background: token.$color_bg_solid_dim;
   border-radius: token.$radius_sm;
 }
 
@@ -21,20 +21,20 @@
 .meta {
   height: 0.875rem;
   width: 40%;
-  margin-bottom: token.$spacing_md;
+  margin-bottom: token.$spacing_12;
 }
 
 .detail_skeleton_thumb {
   width: 100%;
   aspect-ratio: 16 / 9;
-  background: token.$color_background_secondary;
+  background: token.$color_bg_solid_dim;
   border-radius: token.$radius_md;
-  margin-bottom: token.$spacing_lg;
+  margin-bottom: token.$spacing_16;
 }
 
 .detail_skeleton_body {
   @include token.flex_column;
-  gap: token.$spacing_sm;
+  gap: token.$spacing_8;
 }
 
 .short {

--- a/src/shared/ui/skeleton/list/style.module.scss
+++ b/src/shared/ui/skeleton/list/style.module.scss
@@ -1,4 +1,4 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .request_item.skeleton {
   pointer-events: none;
@@ -6,17 +6,17 @@
 
 .skeleton_title {
   width: 14rem;
-  height: token.$spacing_lg;
+  height: token.$spacing_16;
   border-radius: token.$radius_md;
   background: linear-gradient(
                   90deg,
-                  token.$color_background_secondary 25%,
-                  token.$color_border 37%,
-                  token.$color_background_secondary 63%
+                  token.$color_bg_solid_dim 25%,
+                  token.$color_border_default 37%,
+                  token.$color_bg_solid_dim 63%
   );
   background-size: 400% 100%;
   animation: skeleton_shimmer 1.2s ease-in-out infinite;
-  margin-bottom: token.$spacing_sm;
+  margin-bottom: token.$spacing_8;
 }
 
 .skeleton_tag {
@@ -26,9 +26,9 @@
   border-radius: token.$radius_md;
   background: linear-gradient(
                   90deg,
-                  token.$color_background_secondary 25%,
-                  token.$color_border 37%,
-                  token.$color_background_secondary 63%
+                  token.$color_bg_solid_dim 25%,
+                  token.$color_border_default 37%,
+                  token.$color_bg_solid_dim 63%
   );
   background-size: 400% 100%;
   animation: skeleton_shimmer 1.2s ease-in-out infinite;
@@ -41,9 +41,9 @@
   border-radius: token.$radius_md;
   background: linear-gradient(
                   90deg,
-                  token.$color_background_secondary 25%,
-                  token.$color_border 37%,
-                  token.$color_background_secondary 63%
+                  token.$color_bg_solid_dim 25%,
+                  token.$color_border_default 37%,
+                  token.$color_bg_solid_dim 63%
   );
   background-size: 400% 100%;
   animation: skeleton_shimmer 1.2s ease-in-out infinite;

--- a/src/shared/ui/template/style.module.scss
+++ b/src/shared/ui/template/style.module.scss
@@ -1,10 +1,10 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .template {
   @include token.flex_column;
   min-height: 100svh;
-  background-color: token.$color_background_secondary;
-  color: token.$text_normal;
+  background-color: token.$color_bg_solid_dim;
+  color: token.$color_text_body;
 }
 
 .template_main {

--- a/src/widgets/about/history/style.module.scss
+++ b/src/widgets/about/history/style.module.scss
@@ -1,4 +1,4 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .history {
 	--container-width: 1200px;
@@ -6,7 +6,7 @@
 	--left-col: 172px;
 
 	width: 100%;
-	background: token.$color_background_primary;
+	background: token.$color_base_navy_600;
 	position: relative;
 	padding-block: clamp(36px, 7vh, 72px);
 
@@ -17,7 +17,7 @@
 		bottom: 0;
 		left: calc(50vw - var(--container-max) / 2 + var(--left-col) / 2);
 		width: 2px;
-		background: token.$text_inverse;
+		background: token.$color_text_inverse;
 		border-radius: 1px;
 	}
 }
@@ -28,64 +28,64 @@
 	margin: 0 auto;
 	display: grid;
 	grid-template-columns: var(--left-col) 1fr;
-	column-gap: token.$spacing_4xl;
+	column-gap: token.$spacing_32;
 	align-items: start;
 }
 
 .history_years {
 	@include token.flex_column;
-	gap: token.$spacing_xs;
+	gap: token.$spacing_4;
 	position: sticky;
 	top: 96px;
 	z-index: 2;
 }
 
 .history_year_item {
-	@include token.body_medium;
+	@include token.body_medium_medium;
 	/* 폰트 크기 고정 — active 시 color + scale만 변경해 layout shift 제거.
 	   font-weight는 transition 대상에서 제외 — 가변 폰트 아니면 즉시 flip이라 부드럽지 않음 */
-	font-size: token.$font_size_lg;
+	font-size: token.$font_size_18;
 	font-weight: token.$font_weight_regular;
 	background: transparent;
 	border: none;
 	padding: 0;
 	text-align: left;
-	color: token.$color_glass_border;
+	color: token.$color_base_alpha_white_12;
 	cursor: pointer;
 	transform-origin: left center;
 	transition: color token.$transition_base, transform token.$transition_base;
 
 	&:hover {
-		color: token.$text_inverse;
+		color: token.$color_text_inverse;
 	}
 
 	&.is_active {
 		font-weight: token.$font_weight_bold;
-		color: token.$text_inverse;
+		color: token.$color_text_inverse;
 		transform: scale(1.15);
 	}
 }
 
 .history_right {
 	@include token.flex_column;
-	gap: token.$spacing_sm;
+	gap: token.$spacing_8;
 	transition: all token.$transition_slow;
 }
 
 .history_row {
 	display: grid;
 	grid-template-columns: 18px 1fr;
-	column-gap: token.$spacing_sm;
+	column-gap: token.$spacing_8;
 	transition: all token.$transition_base;
 }
 
 .history_row_dot {
 	width: 5px;
 	height: 5px;
-	margin-top: token.$spacing_xs;
+	margin-top: token.$spacing_4;
 	border-radius: token.$radius_full;
-	background: token.$text_inverse;
-	box-shadow: 0 0 0 2px token.$color_glass_light;
+	background: token.$color_text_inverse;
+	box-shadow: 0 0 0 2px token.$color_base_alpha_white_8;
 }
 
 .history_row_body {
@@ -94,45 +94,46 @@
 }
 
 .history_row_title {
-	@include token.heading_3;
-	font-size: token.$font_size_base;
-	color: token.$text_inverse;
+	@include token.heading_small_bold;
+	font-size: token.$font_size_15;
+	color: token.$color_text_inverse;
 }
 
 .history_row_desc {
-	@include token.body_regular;
-	font-size: token.$font_size_sm;
-	color: token.$color_glass_border;
-	line-height: token.$line_height_relaxed;
+	@include token.body_medium;
+	font-size: token.$font_size_14;
+	color: token.$color_base_alpha_white_12;
+	line-height: 1.75;
 }
 
-@include token.tablet {
+@include token.medium {
 	.history {
 		--left-col: 140px;
-		padding-block: token.$spacing_6xl;
+		padding-block: token.$spacing_40;
 	}
 
 	.history_grid {
-		column-gap: token.$spacing_xl;
+		column-gap: token.$spacing_20;
 	}
 
 	.history_year_item {
-		font-size: token.$font_size_sm;
+		font-size: token.$font_size_14;
 	}
 
 	.history_row_title {
-		font-size: token.$font_size_base;
+		font-size: token.$font_size_15;
 	}
 
 	.history_row_desc {
-		font-size: token.$font_size_sm;
+		font-size: token.$font_size_14;
 	}
 }
 
-@include token.mobile {
+@include token.compact {
 	.history {
 		--left-col: 100px;
-		padding-block: token.$spacing_3xl;
+		/* 짧은 다크 스트립처럼 보이지 않도록 세로 호흡 확보 — 의도된 섹션으로 인식 */
+		padding-block: clamp(48px, 9vh, 80px);
 
 		&::before {
 			display: none;
@@ -141,7 +142,8 @@
 
 	.history_grid {
 		grid-template-columns: 1fr;
-		row-gap: token.$spacing_md;
+		/* 연도 바와 본문 사이 분리 — 크램프된 스트립 느낌 제거 */
+		row-gap: token.$spacing_20;
 	}
 
 	.history_years {
@@ -149,12 +151,14 @@
 		top: 64px;
 		width: 100%;
 		flex-direction: row;
-		gap: token.$spacing_xs;
+		gap: token.$spacing_4;
 		overflow-x: auto;
-		padding: token.$spacing_sm token.$spacing_lg;
+		padding: token.$spacing_8 token.$spacing_16 token.$spacing_12;
+		/* 데스크탑 세로 타임라인의 가로 대응 — 연도 바를 본문과 구분 */
+		border-bottom: 1px solid token.$color_base_alpha_white_12;
 		scrollbar-width: none;
 		-ms-overflow-style: none;
-		background: token.$color_background_primary;
+		background: token.$color_base_navy_600;
 
 		&::-webkit-scrollbar {
 			display: none;
@@ -163,38 +167,40 @@
 
 	.history_year_item {
 		flex-shrink: 0;
-		padding: token.$spacing_sm token.$spacing_md;
-		border-radius: token.$radius_md;
-		/* 모바일도 font-size 고정 — active는 background + scale로 강조해 layout shift 제거 */
-		font-size: token.$font_size_sm;
-		background: token.$color_glass_light;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		/* 탭 영역 확보(36px)하되 데스크탑과 동일한 텍스트 탭 스타일 유지 —
+		   회색 pill(=비활성 버튼처럼 보임) 대신 투명 배경 + color/weight로 상태 표현 */
+		min-height: 36px;
+		padding: token.$spacing_4 token.$spacing_8;
+		font-size: token.$font_size_16;
 
 		&.is_active {
-			background: token.$color_glass_border;
 			transform: scale(1.08);
 		}
 	}
 
 	.history_right {
-		padding: 0 token.$spacing_lg;
+		padding: 0 token.$spacing_16;
 	}
 
 	.history_row {
 		grid-template-columns: 14px 1fr;
-		column-gap: token.$spacing_sm;
+		column-gap: token.$spacing_8;
 	}
 
 	.history_row_dot {
-		margin-top: token.$spacing_xs;
+		margin-top: token.$spacing_4;
 		width: 5px;
 		height: 5px;
 	}
 
 	.history_row_title {
-		font-size: token.$font_size_sm;
+		font-size: token.$font_size_14;
 	}
 
 	.history_row_desc {
-		font-size: token.$font_size_xs;
+		font-size: token.$font_size_12;
 	}
 }

--- a/src/widgets/about/introduce/style.module.scss
+++ b/src/widgets/about/introduce/style.module.scss
@@ -1,4 +1,4 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 /**
  * 1080px 컨테이너 폭과 360px 이미지 폭은 디자인 결정으로, 토큰화된 spacing 범위(최대 48px)에
@@ -12,8 +12,8 @@
   width: min(1080px, 92%);
   margin: 0 auto;
   /* clamp로 viewport 기반 스케일 — 브레이크포인트별 gap/padding 재선언 없이 흡수 */
-  gap: clamp(token.$spacing_8xl, 6vw, calc(token.$spacing_8xl * 2));
-  padding-block: clamp(token.$spacing_4xl, 5vw, token.$spacing_5xl);
+  gap: clamp(token.$spacing_48, 6vw, calc(token.$spacing_48 * 2));
+  padding-block: clamp(token.$spacing_32, 5vw, 36px);
   animation: fade_in 0.6s ease both;
 
   &.introduce_reverse {
@@ -45,23 +45,23 @@
   flex: 1 1 0;
   min-width: 0;
   @include token.flex_column;
-  gap: token.$spacing_sm;
+  gap: token.$spacing_8;
   font-family: token.$font_family_primary;
 }
 
 .introduce_title {
-  @include token.heading_2;
-  font-size: token.$font_size_2xl;
-  color: token.$text_strong;
+  @include token.heading_medium_bold;
+  font-size: token.$font_size_24;
+  color: token.$color_text_heading;
   letter-spacing: token.$letter_spacing_tight;
-  line-height: token.$line_height_snug;
+  line-height: 1.3;
 }
 
 .introduce_desc {
-  @include token.body_medium;
-  font-size: token.$font_size_md;
-  color: token.$text_subtle;
-  line-height: token.$line_height_relaxed;
+  @include token.body_medium_medium;
+  font-size: token.$font_size_16;
+  color: token.$color_text_caption;
+  line-height: 1.75;
   white-space: pre-line;
 }
 
@@ -86,13 +86,13 @@
   }
 }
 
-@include token.mobile {
+@include token.compact {
   .introduce {
     @include token.flex_column;
     flex-direction: column-reverse;
     text-align: center;
-    gap: token.$spacing_lg;
-    padding: token.$spacing_2xl token.$spacing_lg;
+    gap: token.$spacing_16;
+    padding: token.$spacing_24 token.$spacing_16;
 
     &.introduce_reverse {
       flex-direction: column-reverse;
@@ -100,7 +100,7 @@
   }
 
   .introduce_text {
-    gap: token.$spacing_xs;
+    gap: token.$spacing_4;
   }
 
   .introduce_image {
@@ -111,11 +111,11 @@
   }
 
   .introduce_title {
-    font-size: token.$font_size_lg;
+    font-size: token.$font_size_18;
   }
 
   .introduce_desc {
-    font-size: token.$font_size_sm;
+    font-size: token.$font_size_14;
   }
 }
 
@@ -123,40 +123,40 @@
  * .introduce 기본 gap/padding-block은 clamp로 viewport에 따라 스케일하므로
  * 브레이크포인트별 재선언은 폰트 크기와 텍스트 내부 gap에 한정.
  */
-@include token.tablet {
+@include token.medium {
   .introduce_text {
-    gap: token.$spacing_md;
+    gap: token.$spacing_12;
   }
 
   .introduce_title {
-    font-size: token.$font_size_2xl;
+    font-size: token.$font_size_24;
   }
 
   .introduce_desc {
-    font-size: token.$font_size_md;
+    font-size: token.$font_size_16;
   }
 }
 
-@include token.laptop {
+@include token.expanded {
   .introduce_text {
-    gap: token.$spacing_lg;
+    gap: token.$spacing_16;
   }
 
   .introduce_title {
-    font-size: token.$font_size_3xl;
+    font-size: token.$font_size_32;
   }
 
   .introduce_desc {
-    font-size: token.$font_size_lg;
+    font-size: token.$font_size_18;
   }
 }
 
-@include token.desktop {
+@include token.large {
   .introduce_title {
-    font-size: token.$font_size_3xl;
+    font-size: token.$font_size_32;
   }
 
   .introduce_desc {
-    font-size: token.$font_size_lg;
+    font-size: token.$font_size_18;
   }
 }

--- a/src/widgets/about/member/card/style.module.scss
+++ b/src/widgets/about/member/card/style.module.scss
@@ -1,20 +1,20 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .member_card {
 	@include token.flex_column;
 	justify-content: flex-start;
 	align-items: center;
-	background: token.$color_background_secondary;
-	border: 1px solid token.$color_border;
+	background: token.$color_bg_solid_dim;
+	border: 1px solid token.$color_border_default;
 	border-radius: token.$radius_lg;
 	width: 100%;
 	max-width: 260px;
 	aspect-ratio: 2 / 3;
-	padding: token.$spacing_lg;
+	padding: token.$spacing_16;
 	text-align: center;
-	color: token.$text_normal;
+	color: token.$color_text_body;
 	cursor: pointer;
-	@include token.hover_lift(-4px, token.$shadow_lg);
+	@include token.hover_lift(-4px, token.$elevation_level3);
 }
 
 .member_card_image {
@@ -22,8 +22,8 @@
 	flex: 1;
 	min-height: 0;
 	border-radius: token.$radius_md;
-	background: token.$color_background;
-	margin-bottom: token.$spacing_sm;
+	background: token.$color_bg_solid;
+	margin-bottom: token.$spacing_8;
 	overflow: hidden;
 
 	img {
@@ -35,24 +35,24 @@
 }
 
 .member_card_position {
-	@include token.body_medium;
-	font-size: token.$font_size_sm;
-	color: token.$text_subtle;
+	@include token.body_medium_medium;
+	font-size: token.$font_size_14;
+	color: token.$color_text_caption;
 	margin-bottom: 2px;
 }
 
 .member_card_name {
-	@include token.heading_3;
-	font-size: token.$font_size_lg;
-	margin: 0 0 token.$spacing_xs;
-	color: token.$text_strong;
+	@include token.heading_small_bold;
+	font-size: token.$font_size_18;
+	margin: 0 0 token.$spacing_4;
+	color: token.$color_text_heading;
 }
 
 .member_card_desc {
-	@include token.body_regular;
-	font-size: token.$font_size_sm;
-	color: token.$text_subtle;
-	line-height: token.$line_height_normal;
+	@include token.body_medium;
+	font-size: token.$font_size_14;
+	color: token.$color_text_caption;
+	line-height: 1.5;
 	text-align: center;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -61,18 +61,23 @@
 	-webkit-box-orient: vertical;
 }
 
-@include token.mobile {
+@include token.compact {
 	.member_card {
-		max-width: 180px;
-		padding: token.$spacing_md;
+		max-width: 100%;
+		padding: token.$spacing_12;
 	}
 
 	.member_card_name {
-		font-size: token.$font_size_md;
+		font-size: token.$font_size_16;
+		word-break: keep-all;
 	}
 
 	.member_card_position,
 	.member_card_desc {
-		font-size: token.$font_size_xs;
+		font-size: token.$font_size_12;
+	}
+
+	.member_card_desc {
+		-webkit-line-clamp: 3;
 	}
 }

--- a/src/widgets/about/member/interview/style.module.scss
+++ b/src/widgets/about/member/interview/style.module.scss
@@ -1,4 +1,4 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .interview {
 }
@@ -7,53 +7,60 @@
   max-block-size: calc(100vh - 32px - 40px);
   overflow-y: auto;
   display: grid;
-  row-gap: token.$spacing_md;
-  padding-inline-end: token.$spacing_xs;
+  row-gap: token.$spacing_12;
+  padding-inline-end: token.$spacing_4;
 }
 
 .interview_empty {
-  @include token.body_regular;
-  font-size: token.$font_size_sm;
-  color: token.$text_subtle;
+  @include token.body_medium;
+  font-size: token.$font_size_14;
+  color: token.$color_text_caption;
 }
 
 .qa {
-  background: token.$color_background;
-  color: token.$text_normal;
-  border: 1px solid token.$color_border;
+  background: token.$color_bg_solid;
+  color: token.$color_text_body;
+  border: 1px solid token.$color_border_default;
   border-radius: token.$radius_lg;
-  padding: token.$spacing_lg;
+  padding: token.$spacing_16;
   display: grid;
-  row-gap: token.$spacing_sm;
+  row-gap: token.$spacing_8;
 }
 
 .qa_q {
-  @include token.heading_3;
-  font-size: token.$font_size_xl;
-  color: token.$text_strong;
-  margin: 0 0 token.$spacing_xs 0;
+  @include token.heading_small_bold;
+  font-size: token.$font_size_20;
+  color: token.$color_text_heading;
+  margin: 0 0 token.$spacing_4 0;
 }
 
 .qa_a {
-  @include token.body_regular;
-  font-size: token.$font_size_md;
-  color: token.$text_normal;
+  @include token.body_medium;
+  font-size: token.$font_size_16;
+  color: token.$color_text_body;
   white-space: pre-line;
-  line-height: token.$line_height_relaxed;
+  line-height: 1.75;
 }
 
 /* mobile */
-@include token.mobile {
+@include token.compact {
+  .interview_scroll {
+    /* 데스크탑은 프로필 고정 + Q&A 독립 스크롤(좌우 배치).
+       모바일은 1컬럼이라 중첩 스크롤 박스 제거 — 페이지 흐름에 자연스럽게 */
+    max-block-size: none;
+    overflow-y: visible;
+  }
+
   .qa {
     border-radius: token.$radius_md;
-    padding: token.$spacing_md;
+    padding: token.$spacing_12;
   }
 
   .qa_q {
-    font-size: token.$font_size_lg;
+    font-size: token.$font_size_18;
   }
 
   .qa_a {
-    font-size: token.$font_size_base;
+    font-size: token.$font_size_15;
   }
 }

--- a/src/widgets/about/member/profile/style.module.scss
+++ b/src/widgets/about/member/profile/style.module.scss
@@ -1,10 +1,11 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .profile {
   @include token.flex_column;
-  color: token.$text_normal;
-  gap: token.$spacing_sm;
-  padding: token.$spacing_lg;
+  color: token.$color_text_body;
+  gap: token.$spacing_8;
+  /* 상단 패딩 0 — 좌측 이미지 top을 우측 Q&A 카드 top과 정렬(좌우 배치 시) */
+  padding: 0 token.$spacing_16 token.$spacing_16;
 }
 
 .profile_image {
@@ -13,7 +14,7 @@
   aspect-ratio: 1 / 1.25;
   border-radius: token.$radius_md;
   overflow: hidden;
-  background: token.$color_background_secondary;
+  background: token.$color_bg_solid_dim;
 
   img {
     object-fit: cover;
@@ -26,13 +27,13 @@
 .profile_image_fallback {
   inline-size: 100%;
   block-size: 100%;
-  background: token.$color_border_light;
+  background: token.$color_border_subtle;
 }
 
 .profile_content {
   @include token.flex_column;
-  gap: token.$spacing_sm;
-  color: token.$text_strong;
+  gap: token.$spacing_8;
+  color: token.$color_text_heading;
 }
 
 .profile_info {
@@ -41,28 +42,28 @@
 }
 
 .profile_position {
-  @include token.body_medium;
-  font-size: token.$font_size_sm;
-  color: token.$text_subtle;
+  @include token.body_medium_medium;
+  font-size: token.$font_size_14;
+  color: token.$color_text_caption;
 }
 
 .profile_name {
-  @include token.heading_2;
-  font-size: token.$font_size_2xl;
-  color: token.$text_strong;
+  @include token.heading_medium_bold;
+  font-size: token.$font_size_24;
+  color: token.$color_text_heading;
 }
 
 .profile_description {
-  @include token.body_regular;
-  font-size: token.$font_size_md;
-  color: token.$text_normal;
-  line-height: token.$line_height_relaxed;
+  @include token.body_medium;
+  font-size: token.$font_size_16;
+  color: token.$color_text_body;
+  line-height: 1.75;
 }
 
 .profile_links {
   display: grid;
   grid-auto-flow: column;
-  gap: token.$spacing_sm;
+  gap: token.$spacing_8;
   justify-content: start;
 }
 
@@ -70,37 +71,37 @@
   inline-size: 28px;
   block-size: 28px;
   border-radius: token.$radius_sm;
-  background: token.$text_strong;
-  color: token.$text_inverse;
+  background: token.$color_text_heading;
+  color: token.$color_text_inverse;
   display: grid;
   place-items: center;
   text-decoration: none;
 
-  @include token.body_medium;
-  font-size: token.$font_size_xs;
+  @include token.body_medium_medium;
+  font-size: token.$font_size_12;
   transition: background token.$transition_base;
 
   &:hover {
-    background: token.$color_primary;
+    background: token.$color_brand_primary;
   }
 }
 
-@include token.mobile {
+@include token.compact {
   .profile {
-    padding: token.$spacing_md;
+    padding: token.$spacing_12;
   }
 
   .profile_name {
-    font-size: token.$font_size_xl;
+    font-size: token.$font_size_20;
   }
 
   .profile_description {
-    font-size: token.$font_size_base;
+    font-size: token.$font_size_15;
   }
 
   .profile_link {
     inline-size: 24px;
     block-size: 24px;
-    font-size: token.$font_size_xs;
+    font-size: token.$font_size_12;
   }
 }

--- a/src/widgets/about/team/style.module.scss
+++ b/src/widgets/about/team/style.module.scss
@@ -1,27 +1,27 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .team {
 	@include token.flex_column;
 	width: 100%;
-	background: token.$color_background_primary;
-	color: token.$text_inverse;
-	gap: token.$spacing_xl;
-	padding-block: token.$spacing_3xl;
-	padding-inline: token.$spacing_2xl;
+	background: token.$color_base_navy_600;
+	color: token.$color_text_inverse;
+	gap: token.$spacing_20;
+	padding-block: 28px;
+	padding-inline: token.$spacing_24;
 }
 
 .team_title {
-	@include token.heading_2;
+	@include token.heading_medium_bold;
 	text-align: center;
-	font-size: token.$font_size_2xl;
-	padding-block: token.$spacing_lg;
-	color: token.$text_inverse;
+	font-size: token.$font_size_24;
+	padding-block: token.$spacing_16;
+	color: token.$color_text_inverse;
 }
 
 .team_grid {
 	display: grid;
 	grid-template-columns: repeat(3, minmax(200px, 260px));
-	gap: token.$spacing_xl;
+	gap: token.$spacing_20;
 	justify-content: center;
 	align-items: start;
 	margin: 0 auto;
@@ -29,36 +29,36 @@
 	max-width: 920px;
 }
 
-@include token.laptop {
+@include token.expanded {
 	.team_grid {
 		grid-template-columns: repeat(2, minmax(180px, 240px));
 		max-width: 520px;
 	}
 }
 
-@include token.tablet {
+@include token.medium {
 	.team_grid {
 		grid-template-columns: repeat(2, minmax(160px, 220px));
-		gap: token.$spacing_lg;
+		gap: token.$spacing_16;
 		max-width: 480px;
 	}
 }
 
-@include token.mobile {
+@include token.compact {
 	.team {
-		gap: token.$spacing_lg;
-		padding-block: token.$spacing_2xl;
-		padding-inline: token.$spacing_lg;
+		gap: token.$spacing_16;
+		padding-block: token.$spacing_24;
+		padding-inline: token.$spacing_16;
 	}
 
 	.team_title {
-		font-size: token.$font_size_xl;
-		padding-block: token.$spacing_md;
+		font-size: token.$font_size_20;
+		padding-block: token.$spacing_12;
 	}
 
 	.team_grid {
-		grid-template-columns: repeat(2, 1fr);
-		gap: token.$spacing_md;
+		grid-template-columns: repeat(2, minmax(140px, 1fr));
+		gap: token.$spacing_12;
 		max-width: 100%;
 	}
 }

--- a/src/widgets/blog/card/style.module.scss
+++ b/src/widgets/blog/card/style.module.scss
@@ -1,20 +1,20 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .blog_card {
   @include token.flex_column;
-  background: token.$color_background;
-  border: 1px solid token.$color_border;
+  background: token.$color_bg_solid;
+  border: 1px solid token.$color_border_default;
   border-radius: token.$radius_lg;
-  padding: token.$spacing_md;
+  padding: token.$spacing_12;
   text-decoration: none;
-  color: token.$text_normal;
+  color: token.$color_text_body;
   height: 100%;
   cursor: pointer;
-  @include token.hover_lift(-4px, token.$shadow_elevated);
+  @include token.hover_lift(-4px, token.$elevation_level4);
 
   &:hover {
-    background: token.$color_background_secondary;
-    border-color: token.$color_primary_hover;
+    background: token.$color_bg_solid_dim;
+    border-color: token.$color_border_hover;
   }
 }
 
@@ -22,7 +22,7 @@
   width: 100%;
   aspect-ratio: 4 / 3;
   border-radius: token.$radius_md;
-  border: 1px solid token.$color_border;
+  border: 1px solid token.$color_border_default;
 
   img {
     object-fit: cover;
@@ -35,14 +35,14 @@
 .blog_card_meta {
   display: flex;
   align-items: center;
-  gap: token.$spacing_xs;
-  margin-top: token.$spacing_sm;
-  color: token.$text_subtle;
-  font-size: token.$font_size_xs;
+  gap: token.$spacing_4;
+  margin-top: token.$spacing_8;
+  color: token.$color_text_caption;
+  font-size: token.$font_size_12;
 }
 
 .blog_card_time {
-  @include token.body_regular;
+  @include token.body_medium;
 }
 
 .blog_card_dot {
@@ -50,15 +50,15 @@
 }
 
 .blog_card_views {
-  font-size: token.$font_size_sm;
+  font-size: token.$font_size_14;
   font-weight: token.$font_weight_regular;
 }
 
 .blog_card_title {
-  @include token.heading_3;
-  font-size: token.$font_size_md;
-  margin-top: token.$spacing_sm;
-  color: token.$text_strong;
+  @include token.heading_small_bold;
+  font-size: token.$font_size_16;
+  margin-top: token.$spacing_8;
+  color: token.$color_text_heading;
   word-break: keep-all;
   overflow-wrap: break-word;
   display: -webkit-box;
@@ -68,12 +68,31 @@
 }
 
 .blog_card_excerpt {
-  @include token.body_regular;
-  font-size: token.$font_size_sm;
-  margin-top: token.$spacing_xs;
-  color: token.$text_subtle;
+  @include token.body_medium;
+  font-size: token.$font_size_14;
+  margin-top: token.$spacing_4;
+  color: token.$color_text_caption;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+
+@include token.compact {
+  .blog_card {
+    padding: token.$spacing_8;
+  }
+
+  .blog_card_title {
+    font-size: token.$font_size_14;
+    -webkit-line-clamp: 3;
+  }
+
+  .blog_card_excerpt {
+    font-size: token.$font_size_12;
+  }
+
+  .blog_card_meta {
+    font-size: token.$font_size_12;
+  }
 }

--- a/src/widgets/blog/list/style.module.scss
+++ b/src/widgets/blog/list/style.module.scss
@@ -1,4 +1,4 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .blog_list {
 	display: flex;
@@ -9,26 +9,26 @@
 		@include token.flex_column;
 		align-items: center;
 		text-align: center;
-		gap: token.$spacing_sm;
-		margin-bottom: token.$spacing_3xl;
+		gap: token.$spacing_8;
+		margin-bottom: 28px;
 
 		h2 {
-			@include token.heading_2;
-			font-size: token.$font_size_2xl;
-			color: token.$text_strong;
+			@include token.heading_medium_bold;
+			font-size: token.$font_size_24;
+			color: token.$color_text_heading;
 		}
 
 		p {
-			@include token.body_medium;
-			font-size: token.$font_size_lg;
-			color: token.$text_subtle;
+			@include token.body_medium_medium;
+			font-size: token.$font_size_18;
+			color: token.$color_text_caption;
 		}
 	}
 
 	&_grid {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(280px, 384px));
-		gap: token.$spacing_2xl;
+		gap: token.$spacing_24;
 		width: 100%;
 		max-width: 1200px;
 		margin: 0 auto;
@@ -40,28 +40,28 @@
 	}
 
 	&_empty {
-		@include token.body_regular;
-		font-size: token.$font_size_xl;
-		margin-top: token.$spacing_3xl;
-		color: token.$text_subtle;
+		@include token.body_medium;
+		font-size: token.$font_size_20;
+		margin-top: 28px;
+		color: token.$color_text_caption;
 		text-align: center;
 	}
 }
 
-@include token.mobile {
+@include token.compact {
 	.blog_list_grid {
-		gap: token.$spacing_lg;
+		gap: token.$spacing_16;
 	}
 
 	.blog_list_header {
-		margin-bottom: token.$spacing_2xl;
+		margin-bottom: token.$spacing_24;
 
 		h2 {
-			font-size: token.$font_size_xl;
+			font-size: token.$font_size_20;
 		}
 
 		p {
-			font-size: token.$font_size_base;
+			font-size: token.$font_size_15;
 		}
 	}
 }

--- a/src/widgets/layout/provider/index.tsx
+++ b/src/widgets/layout/provider/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertProvider, ToastProvider } from "@bigtablet/design-system";
+import { AlertProvider, ThemeProvider, ToastProvider } from "@bigtablet/design-system";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import dynamic from "next/dynamic";
 import { type ReactNode, useMemo } from "react";
@@ -38,14 +38,18 @@ export default function Providers({ children }: Props) {
 	);
 
 	return (
-		<AlertProvider>
-			<ToastProvider>
-				<QueryClientProvider client={queryClient}>
-					<ToastBridgeProvider />
-					{children}
-					<DeferredCookieConsent />
-				</QueryClientProvider>
-			</ToastProvider>
-		</AlertProvider>
+		/* defaultMode="light" 고정 — DS 3.1 토큰/테마 인프라는 도입하되, 현 사이트는
+		   라이트 기반(특정 섹션만 다크)이라 system/dark 자동 전환은 추후 다크 대응 후 활성화 */
+		<ThemeProvider defaultMode="light">
+			<AlertProvider>
+				<ToastProvider>
+					<QueryClientProvider client={queryClient}>
+						<ToastBridgeProvider />
+						{children}
+						<DeferredCookieConsent />
+					</QueryClientProvider>
+				</ToastProvider>
+			</AlertProvider>
+		</ThemeProvider>
 	);
 }

--- a/src/widgets/main/banner/index.tsx
+++ b/src/widgets/main/banner/index.tsx
@@ -86,7 +86,7 @@ const Banner = () => {
 					target="_blank"
 					rel="noopener noreferrer"
 				>
-					<Button variant="primary" size="lg">
+					<Button variant="filled" size="lg">
 						{t("button")}
 					</Button>
 				</a>

--- a/src/widgets/main/banner/style.module.scss
+++ b/src/widgets/main/banner/style.module.scss
@@ -1,4 +1,4 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .banner {
 	position: relative;
@@ -6,8 +6,8 @@
 	height: 95vh;
 	overflow: hidden;
 	white-space: pre-line;
-	color: token.$text_inverse;
-	background: token.$color_background;
+	color: token.$color_text_inverse;
+	background: token.$color_bg_solid;
 }
 
 .banner_video {
@@ -35,7 +35,7 @@
 .banner_overlay {
 	position: absolute;
 	inset: 0;
-	background: token.$color_overlay;
+	background: token.$color_bg_overlay;
 }
 
 .banner_content {
@@ -43,24 +43,24 @@
 	@include token.flex_center;
 	position: relative;
 	height: 100%;
-	gap: token.$spacing_3xl;
-	color: token.$text_inverse;
+	gap: 28px;
+	color: token.$color_text_inverse;
 	text-align: center;
-	padding-inline: token.$spacing_xl;
+	padding-inline: token.$spacing_20;
 }
 
 .banner_title {
-	@include token.heading_1;
-	font-size: clamp(token.$font_size_3xl, 5vw, token.$font_size_4xl);
-	line-height: token.$line_height_tight;
-	color: token.$text_inverse;
+	@include token.display_small_bold;
+	font-size: clamp(token.$font_size_32, 5vw, token.$font_size_40);
+	line-height: 1.25;
+	color: token.$color_text_inverse;
 	animation: fade_up 0.8s ease-out both;
 }
 
 .banner_description {
-	@include token.body_medium;
-	font-size: clamp(token.$font_size_md, 2vw, token.$font_size_xl);
-	color: token.$text_inverse;
+	@include token.body_medium_medium;
+	font-size: clamp(token.$font_size_16, 2vw, token.$font_size_20);
+	color: token.$color_text_inverse;
 	opacity: 0.9;
 	animation: fade_up 0.6s ease-out 0.3s both;
 }
@@ -91,15 +91,15 @@
 
 .banner_scroll_indicator {
 	position: absolute;
-	bottom: token.$spacing_2xl;
+	bottom: token.$spacing_24;
 	left: 50%;
 	transform: translateX(-50%);
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	gap: token.$spacing_xs;
+	gap: token.$spacing_4;
 	color: rgba(255, 255, 255, 0.5);
-	font-size: token.$font_size_xs;
+	font-size: token.$font_size_12;
 	animation: bounce_scroll 2s ease-in-out infinite;
 }
 
@@ -112,17 +112,17 @@
 	}
 }
 
-@include token.mobile {
+@include token.compact {
 	.banner {
 		height: 80vh;
 	}
 
 	.banner_content {
-		gap: token.$spacing_2xl;
-		padding-inline: token.$spacing_lg;
+		gap: token.$spacing_24;
+		padding-inline: token.$spacing_16;
 	}
 
 	.banner_scroll_indicator {
-		bottom: token.$spacing_lg;
+		bottom: token.$spacing_16;
 	}
 }

--- a/src/widgets/main/collaborations/style.module.scss
+++ b/src/widgets/main/collaborations/style.module.scss
@@ -1,22 +1,22 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .collabs {
 	@include token.flex_column;
-	padding: token.$spacing_xl 0 token.$spacing_md;
-	color: token.$text_inverse;
-	gap: token.$spacing_3xl;
+	padding: token.$spacing_20 0 token.$spacing_12;
+	color: token.$color_text_inverse;
+	gap: 28px;
 }
 
 .collabs_title {
 	text-align: center;
-	font-size: token.$font_size_3xl;
-	color: token.$text_inverse;
+	font-size: token.$font_size_32;
+	color: token.$color_text_inverse;
 }
 
 .collabs_viewport {
 	position: relative;
 	overflow: hidden;
-	padding-block: token.$spacing_md;
+	padding-block: token.$spacing_12;
 	width: 100%;
 }
 
@@ -55,11 +55,11 @@
 	@include token.flex_center;
 	width: clamp(200px, 18vw, 280px);
 	height: clamp(64px, 6vw, 88px);
-	margin-right: token.$spacing_2xl;
+	margin-right: token.$spacing_24;
 	border-radius: token.$radius_lg;
-	background: token.$color_background;
-	box-shadow: token.$shadow_sm;
-	padding: token.$spacing_md token.$spacing_lg;
+	background: token.$color_bg_solid;
+	box-shadow: token.$elevation_level1;
+	padding: token.$spacing_12 token.$spacing_16;
 	overflow: hidden;
 	transition:
 		transform token.$transition_fast,
@@ -74,19 +74,19 @@
 	}
 }
 
-@include token.mobile {
+@include token.compact {
 	.collabs {
-		gap: token.$spacing_xl;
+		gap: token.$spacing_20;
 	}
 
 	.collabs_title {
-		font-size: token.$font_size_xl;
+		font-size: token.$font_size_20;
 	}
 
 	.collabs_card {
 		width: 180px;
 		height: 56px;
-		margin-right: token.$spacing_lg;
-		padding: token.$spacing_sm token.$spacing_md;
+		margin-right: token.$spacing_16;
+		padding: token.$spacing_8 token.$spacing_12;
 	}
 }

--- a/src/widgets/main/problem/style.module.scss
+++ b/src/widgets/main/problem/style.module.scss
@@ -1,4 +1,4 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .problem {
   @include token.flex_between;
@@ -7,8 +7,8 @@
   max-width: 1200px;
   margin: 0 auto;
   white-space: pre-line;
-  gap: token.$spacing_2xl;
-  color: token.$text_normal;
+  gap: token.$spacing_24;
+  color: token.$color_text_body;
 }
 
 /* 기본은 invisible — IntersectionObserver 가 is_visible 부여하면 fade-up 시작.
@@ -40,38 +40,38 @@
 }
 
 .problem_title {
-  @include token.heading_2;
+  @include token.heading_medium_bold;
   flex: 0 0 35%;
-  font-size: token.$font_size_4xl;
-  color: token.$text_strong;
-  line-height: token.$line_height_snug;
+  font-size: token.$font_size_40;
+  color: token.$color_text_heading;
+  line-height: 1.3;
 }
 
 .problem_description {
-  @include token.body_medium;
+  @include token.body_medium_medium;
   flex: 0 0 55%;
-  font-size: token.$font_size_xl;
-  color: token.$text_normal;
-  line-height: token.$line_height_relaxed;
+  font-size: token.$font_size_20;
+  color: token.$color_text_body;
+  line-height: 1.75;
 }
 
-@include token.mobile {
+@include token.compact {
   .problem {
     @include token.flex_column;
     width: 88%;
     text-align: left;
-    gap: token.$spacing_xl;
+    gap: token.$spacing_20;
   }
 
   .problem_title {
-    font-size: token.$font_size_2xl;
-    line-height: token.$line_height_snug;
+    font-size: token.$font_size_24;
+    line-height: 1.3;
     flex: 0 0 auto;
   }
 
   .problem_description {
-    font-size: token.$font_size_lg;
-    line-height: token.$line_height_relaxed;
+    font-size: token.$font_size_18;
+    line-height: 1.75;
     flex: 0 0 auto;
   }
 }

--- a/src/widgets/main/solution/card/style.module.scss
+++ b/src/widgets/main/solution/card/style.module.scss
@@ -1,4 +1,4 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .solution_card {
 	appearance: none;
@@ -13,18 +13,18 @@
 	aspect-ratio: 6 / 7;
 	border-radius: token.$radius_lg;
 	overflow: hidden;
-	background: token.$color_primary;
-	box-shadow: token.$shadow_md;
+	background: token.$color_brand_primary;
+	box-shadow: token.$elevation_level2;
 	-webkit-tap-highlight-color: transparent;
 	transition: transform token.$transition_fast, box-shadow token.$transition_base;
 
 	&:focus-visible {
-		outline: 2px solid token.$color_primary;
+		outline: 2px solid token.$color_brand_primary;
 		outline-offset: 3px;
 	}
 
 	&:hover {
-		box-shadow: token.$shadow_lg;
+		box-shadow: token.$elevation_level3;
 	}
 
 	&:active {
@@ -46,11 +46,13 @@
 }
 
 .solution_card_overlay {
+	/* 이미지 스크림 — 원본 overlay 색 유지. codemod 가 overlay_light(rgba(0,0,0,0.3))
+	   를 alpha_black_38(rgba(26,26,26,0.38)) 로 매핑해 불투명도·틴트가 틀어졌던 것 복원 */
 	background: linear-gradient(
 		180deg,
-		token.$color_overlay_light 0%,
-		token.$color_overlay 40%,
-		token.$color_overlay_strong 100%
+		rgba(0, 0, 0, 0.3) 0%,
+		token.$color_bg_overlay 40%,
+		rgba(0, 0, 0, 0.7) 100%
 	);
 	z-index: 1;
 }
@@ -62,33 +64,33 @@
 	place-items: center;
 	z-index: 2;
 
-	@include token.heading_3;
-	font-size: clamp(token.$font_size_lg, 2vw, token.$font_size_2xl);
-	line-height: token.$line_height_snug;
-	color: token.$text_inverse;
+	@include token.heading_small_bold;
+	font-size: clamp(token.$font_size_18, 2vw, token.$font_size_24);
+	line-height: 1.3;
+	color: token.$color_text_inverse;
 
 	text-align: center;
 	white-space: pre-line;
-	text-shadow: 0 2px 10px token.$color_glass_dark;
-	padding: token.$spacing_md;
+	text-shadow: 0 2px 10px token.$color_base_alpha_black_50;
+	padding: token.$spacing_12;
 	pointer-events: none;
 	word-break: keep-all;
 	overflow-wrap: break-word;
 }
 
-@include token.desktop {
+@include token.large {
 	.solution_card {
 		width: 100%;
 	}
 }
 
-@include token.laptop {
+@include token.expanded {
 	.solution_card {
 		width: 100%;
 	}
 }
 
-@include token.mobile {
+@include token.compact {
 	.solution_card {
 		width: 44vw;
 		max-width: 200px;
@@ -96,7 +98,7 @@
 	}
 
 	.solution_card_title {
-		font-size: token.$font_size_base;
-		padding: token.$spacing_sm;
+		font-size: token.$font_size_15;
+		padding: token.$spacing_8;
 	}
 }

--- a/src/widgets/main/solution/modal/style.module.scss
+++ b/src/widgets/main/solution/modal/style.module.scss
@@ -1,21 +1,21 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .solution_modal_backdrop {
 	position: fixed;
 	inset: 0;
-	z-index: token.$z_modal;
+	z-index: token.$z_level5;
 	display: grid;
 	place-items: center;
-	padding: token.$spacing_2xl;
+	padding: token.$spacing_24;
 	/* 진한 백드롭 + blur — 뒤 콘텐츠 가독성 차단해 모달에 시선 집중 */
-	background: token.$color_overlay_strong;
+	background: rgba(0, 0, 0, 0.7);
 	backdrop-filter: blur(8px);
 	-webkit-backdrop-filter: blur(8px);
 	/* fade-in으로 backdrop-filter 잔상 방지 */
 	animation: solution_modal_backdrop_fade_in 200ms ease-out;
 
-	@include token.laptop {
-		padding: token.$spacing_3xl;
+	@include token.expanded {
+		padding: 28px;
 	}
 }
 
@@ -45,7 +45,7 @@
 	border-radius: token.$radius_xl;
 	/* nav 화살표가 모달 외부로 빠지므로 visible. 내부 panel 슬라이드는 content가 hidden 처리. */
 	overflow: visible;
-	background: token.$color_primary;
+	background: token.$color_brand_primary;
 	transform-origin: center center;
 	transform: translate(var(--from-dx, 0), var(--from-dy, 0)) scale(var(--from-sx, 1), var(--from-sy, 1));
 	opacity: 0;
@@ -72,8 +72,8 @@
 	background: rgba(0, 0, 0, 0.45);
 	backdrop-filter: blur(10px);
 	-webkit-backdrop-filter: blur(10px);
-	color: token.$text_inverse;
-	font-size: token.$font_size_2xl;
+	color: token.$color_text_inverse;
+	font-size: token.$font_size_24;
 	cursor: pointer;
 	transition:
 		background token.$transition_base,
@@ -87,16 +87,16 @@
 		transform: translateY(-50%) scale(0.96);
 	}
 
-	@include token.laptop {
+	@include token.expanded {
 		width: 56px;
 		height: 56px;
-		font-size: token.$font_size_3xl;
+		font-size: token.$font_size_32;
 	}
 
-	@include token.mobile {
+	@include token.compact {
 		width: 40px;
 		height: 40px;
-		font-size: token.$font_size_xl;
+		font-size: token.$font_size_20;
 	}
 }
 
@@ -104,33 +104,33 @@
 .solution_modal_nav_prev {
 	left: -64px;
 
-	@include token.laptop {
+	@include token.expanded {
 		left: -72px;
 	}
 
 	/* 모바일은 모달이 viewport 가득 차서 외부 공간 없음 — 안쪽 유지 */
-	@include token.tablet {
-		left: token.$spacing_xs;
+	@include token.medium {
+		left: token.$spacing_4;
 	}
 
-	@include token.mobile {
-		left: token.$spacing_xs;
+	@include token.compact {
+		left: token.$spacing_4;
 	}
 }
 
 .solution_modal_nav_next {
 	right: -64px;
 
-	@include token.laptop {
+	@include token.expanded {
 		right: -72px;
 	}
 
-	@include token.tablet {
-		right: token.$spacing_xs;
+	@include token.medium {
+		right: token.$spacing_4;
 	}
 
-	@include token.mobile {
-		right: token.$spacing_xs;
+	@include token.compact {
+		right: token.$spacing_4;
 	}
 }
 
@@ -166,11 +166,11 @@
 	display: grid;
 	grid-template-columns: 1fr 1.35fr;
 
-	@include token.tablet {
+	@include token.medium {
 		grid-template-columns: 1fr;
 	}
 
-	@include token.mobile {
+	@include token.compact {
 		grid-template-columns: 1fr;
 	}
 }
@@ -185,37 +185,37 @@
 	/* safe center — 콘텐츠 길이가 컨테이너 초과 시 start로 fallback해 상단 잘림 방지 */
 	justify-content: safe center;
 	z-index: 2;
-	padding: clamp(token.$spacing_2xl, 4vw, token.$spacing_4xl);
-	gap: token.$spacing_lg;
-	color: token.$text_inverse;
+	padding: clamp(token.$spacing_24, 4vw, token.$spacing_32);
+	gap: token.$spacing_16;
+	color: token.$color_text_inverse;
 	overflow: auto;
-	line-height: token.$line_height_relaxed;
+	line-height: 1.75;
 	/* 우측 끝까지 단색 유지 — right panel의 fade와 자연스럽게 만나 라인 형성 안 함 */
-	background: token.$color_background_darkest;
+	background: #020617;
 }
 
 .solution_modal_title {
-	@include token.heading_2;
+	@include token.heading_medium_bold;
 	font-weight: token.$font_weight_bold;
 	letter-spacing: token.$letter_spacing_tight;
 	white-space: pre-line;
-	line-height: token.$line_height_tight;
+	line-height: 1.25;
 	margin: 0;
 }
 
 .solution_modal_desc {
-	@include token.body_regular;
-	color: token.$text_inverse;
+	@include token.body_medium;
+	color: token.$color_text_inverse;
 	opacity: 0.85;
 	white-space: pre-line;
 	margin: 0;
-	line-height: token.$line_height_relaxed;
+	line-height: 1.75;
 	max-width: 42ch;
 }
 
 .solution_modal_right {
 	position: relative;
-	background: token.$color_primary;
+	background: token.$color_brand_primary;
 	overflow: hidden;
 
 	/* 좌측 가장자리 → 영상으로 부드럽게 fade. left panel과 같은 색에서 시작해 경계 라인 제거. */
@@ -227,7 +227,7 @@
 		width: 240px;
 		background: linear-gradient(
 			to right,
-			token.$color_background_darkest 0%,
+			#020617 0%,
 			rgba(0, 0, 0, 0.5) 40%,
 			transparent 100%
 		);
@@ -235,11 +235,11 @@
 		z-index: 1;
 	}
 
-	@include token.tablet {
+	@include token.medium {
 		display: none;
 	}
 
-	@include token.mobile {
+	@include token.compact {
 		display: none;
 	}
 }

--- a/src/widgets/main/solution/section/style.module.scss
+++ b/src/widgets/main/solution/section/style.module.scss
@@ -1,17 +1,17 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .solution {
 	@include token.flex_column;
 	@include token.flex_center;
 	width: 100%;
-	gap: token.$spacing_3xl;
-	color: token.$text_inverse;
+	gap: 28px;
+	color: token.$color_text_inverse;
 }
 
 .solution_title {
-	@include token.heading_2;
-	font-size: clamp(token.$font_size_2xl, 4vw, token.$font_size_4xl);
-	color: token.$text_inverse;
+	@include token.heading_medium_bold;
+	font-size: clamp(token.$font_size_24, 4vw, token.$font_size_40);
+	color: token.$color_text_inverse;
 	text-align: center;
 	white-space: pre-line;
 }
@@ -20,23 +20,23 @@
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: center;
-	gap: token.$spacing_xl;
+	gap: token.$spacing_20;
 	width: 100%;
 	max-width: 1600px;
 	margin: 0 auto;
-	padding: 0 token.$spacing_xl;
+	padding: 0 token.$spacing_20;
 }
 
-@include token.desktop {
+@include token.large {
 	.solution_grid {
 		display: grid;
 		grid-template-columns: repeat(5, 1fr);
 	}
 }
 
-@include token.laptop {
+@include token.expanded {
 	.solution_title {
-		font-size: token.$font_size_3xl;
+		font-size: token.$font_size_32;
 	}
 
 	.solution_grid {
@@ -45,24 +45,24 @@
 	}
 }
 
-@include token.tablet {
+@include token.medium {
 	.solution {
-		gap: token.$spacing_2xl;
+		gap: token.$spacing_24;
 	}
 
 	.solution_title {
-		font-size: token.$font_size_2xl;
+		font-size: token.$font_size_24;
 	}
 
 	.solution_grid {
-		gap: token.$spacing_lg;
-		padding: 0 token.$spacing_lg;
+		gap: token.$spacing_16;
+		padding: 0 token.$spacing_16;
 	}
 }
 
-@include token.mobile {
+@include token.compact {
 	.solution_grid {
-		gap: token.$spacing_md;
-		padding: 0 token.$spacing_md;
+		gap: token.$spacing_12;
+		padding: 0 token.$spacing_12;
 	}
 }

--- a/src/widgets/news/card/style.module.scss
+++ b/src/widgets/news/card/style.module.scss
@@ -1,25 +1,25 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .news_card {
   @include token.flex_column;
   height: 100%;
-  padding: token.$spacing_md;
-  background: token.$color_background;
-  border: 1px solid token.$color_border;
+  padding: token.$spacing_12;
+  background: token.$color_bg_solid;
+  border: 1px solid token.$color_border_default;
   border-radius: token.$radius_lg;
   text-decoration: none;
-  color: token.$text_normal;
-  @include token.hover_lift(-4px, token.$shadow_elevated);
+  color: token.$color_text_body;
+  @include token.hover_lift(-4px, token.$elevation_level4);
 
   &:hover {
-    background: token.$color_background_secondary;
-    border-color: token.$color_primary_hover;
+    background: token.$color_bg_solid_dim;
+    border-color: token.$color_border_hover;
   }
 
   &:focus-visible {
     outline: none;
-    border-color: token.$color_primary;
-    box-shadow: token.$glow_accent;
+    border-color: token.$color_brand_primary;
+    box-shadow: 0 0 20px rgba(59, 130, 246, 0.35);
   }
 }
 
@@ -27,7 +27,7 @@
   width: 100%;
   aspect-ratio: 4 / 3;
   border-radius: token.$radius_md;
-  border: 1px solid token.$color_border;
+  border: 1px solid token.$color_border_default;
 }
 
 .news_card_img {
@@ -37,19 +37,34 @@
 .news_card_meta {
   display: flex;
   align-items: center;
-  gap: token.$spacing_xs;
-  margin-top: token.$spacing_sm;
-  color: token.$text_subtle;
-  font-size: token.$font_size_xs;
+  gap: token.$spacing_4;
+  margin-top: token.$spacing_8;
+  color: token.$color_text_caption;
+  font-size: token.$font_size_12;
 }
 
 .news_card_title {
-  @include token.heading_3;
-  margin-top: token.$spacing_sm;
-  font-size: token.$font_size_md;
-  color: token.$text_strong;
+  @include token.heading_small_bold;
+  margin-top: token.$spacing_8;
+  font-size: token.$font_size_16;
+  color: token.$color_text_heading;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+
+@include token.compact {
+  .news_card {
+    padding: token.$spacing_8;
+  }
+
+  .news_card_title {
+    font-size: token.$font_size_14;
+    -webkit-line-clamp: 3;
+  }
+
+  .news_card_meta {
+    font-size: token.$font_size_12;
+  }
 }

--- a/src/widgets/news/list/style.module.scss
+++ b/src/widgets/news/list/style.module.scss
@@ -1,10 +1,10 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .news_list {
   @include token.flex_column;
   width: 100%;
   flex: 1;
-  padding: token.$spacing_xl 0;
+  padding: token.$spacing_20 0;
   align-items: center;
 }
 
@@ -13,7 +13,7 @@
   max-width: 1200px;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 384px));
-  gap: token.$spacing_xl;
+  gap: token.$spacing_20;
   justify-content: start;
 }
 
@@ -24,8 +24,24 @@
   flex: 1;
   min-height: 240px;
   width: 100%;
-  @include token.body_regular;
-  font-size: token.$font_size_lg;
-  color: token.$text_subtle;
+  @include token.body_medium;
+  font-size: token.$font_size_18;
+  color: token.$color_text_caption;
   text-align: center;
+}
+
+@include token.compact {
+  .news_list {
+    padding: token.$spacing_16 0;
+  }
+
+  .news_list_grid {
+    grid-template-columns: 1fr;
+    gap: token.$spacing_16;
+    padding: 0 token.$spacing_12;
+  }
+
+  .news_list_empty {
+    font-size: token.$font_size_16;
+  }
 }

--- a/src/widgets/policies/content/style.module.scss
+++ b/src/widgets/policies/content/style.module.scss
@@ -1,50 +1,77 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .policy {
-	padding: token.$spacing_5xl 0;
+	padding: 36px 0;
 	@include token.flex_column;
 	max-width: 1200px;
 	width: 100%;
-	gap: token.$spacing_2xl;
+	gap: token.$spacing_24;
 	margin: 0 auto;
 }
 
 .policy_body {
 	@include token.flex_column;
-	gap: token.$spacing_2xl;
+	gap: token.$spacing_24;
 
 	h1 {
-		@include token.heading_1;
-		font-size: token.$font_size_4xl;
-		color: token.$text_strong;
+		@include token.display_small_bold;
+		font-size: token.$font_size_40;
+		color: token.$color_text_heading;
 	}
 
 	h2 {
-		@include token.heading_2;
-		font-size: token.$font_size_2xl;
-		color: token.$text_normal;
+		@include token.heading_medium_bold;
+		font-size: token.$font_size_24;
+		color: token.$color_text_body;
 	}
 
 	p {
-		@include token.body_regular;
-		font-size: token.$font_size_md;
-		color: token.$text_normal;
-		line-height: token.$line_height_relaxed;
+		@include token.body_medium;
+		font-size: token.$font_size_16;
+		color: token.$color_text_body;
+		line-height: 1.75;
 	}
 
 	a {
-		color: token.$color_primary;
+		color: token.$color_brand_primary;
 		text-decoration: underline;
 	}
 
 	ul, ol {
-		padding-left: token.$spacing_xl;
+		padding-left: token.$spacing_20;
 
 		li {
-			@include token.body_regular;
-			font-size: token.$font_size_md;
-			color: token.$text_normal;
-			line-height: token.$line_height_relaxed;
+			@include token.body_medium;
+			font-size: token.$font_size_16;
+			color: token.$color_text_body;
+			line-height: 1.75;
+		}
+	}
+}
+
+@include token.compact {
+	.policy {
+		padding: 28px token.$spacing_12;
+		gap: token.$spacing_20;
+	}
+
+	.policy_body {
+		gap: token.$spacing_20;
+
+		h1 {
+			font-size: token.$font_size_24;
+		}
+
+		h2 {
+			font-size: token.$font_size_18;
+		}
+
+		p, ul li, ol li {
+			font-size: token.$font_size_14;
+		}
+
+		ul, ol {
+			padding-left: token.$spacing_16;
 		}
 	}
 }

--- a/src/widgets/recruit/main/header/index.tsx
+++ b/src/widgets/recruit/main/header/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button, Select, type SelectOption, TextField } from "@bigtablet/design-system";
+import { Button, Dropdown, type DropdownOption, TextField } from "@bigtablet/design-system";
 import { memo, useState } from "react";
 import type { RecruitSearchFilters } from "src/entities/recruit/api/recruit.api";
 import {
@@ -17,7 +17,7 @@ import styles from "./style.module.scss";
 
 /* 정적 옵션 — 매 렌더 재생성 방지 위해 모듈 스코프 상수로 */
 const toOptions = <T extends string>(codes: readonly T[], getLabel: (code: T) => string) =>
-	codes.map<SelectOption>((code) => ({ value: code, label: getLabel(code) }));
+	codes.map<DropdownOption>((code) => ({ value: code, label: getLabel(code) }));
 
 const DEPARTMENT_OPTIONS = toOptions(DEPARTMENTS, departmentLabel);
 const EDUCATION_OPTIONS = toOptions(EDUCATIONS, educationLabel);
@@ -49,7 +49,7 @@ const RecruitHeader = ({ filters, onChange }: Props) => {
 						className={styles.recruit_search_field}
 					/>
 
-					<Select
+					<Dropdown
 						placeholder="직무"
 						options={DEPARTMENT_OPTIONS}
 						value={filters.job ?? null}
@@ -58,7 +58,7 @@ const RecruitHeader = ({ filters, onChange }: Props) => {
 						className={styles.recruit_search_select}
 					/>
 
-					<Select
+					<Dropdown
 						placeholder="학력"
 						options={EDUCATION_OPTIONS}
 						value={filters.education ?? null}
@@ -67,7 +67,7 @@ const RecruitHeader = ({ filters, onChange }: Props) => {
 						className={styles.recruit_search_select}
 					/>
 
-					<Select
+					<Dropdown
 						placeholder="고용형태"
 						options={RECRUIT_TYPE_OPTIONS}
 						value={filters.career ?? null}
@@ -76,7 +76,7 @@ const RecruitHeader = ({ filters, onChange }: Props) => {
 						className={styles.recruit_search_select}
 					/>
 
-					<Button variant="primary" size="sm" width="auto" onClick={() => setOpen(true)}>
+					<Button variant="filled" size="sm" onClick={() => setOpen(true)}>
 						인재풀 등록하기
 					</Button>
 				</div>

--- a/src/widgets/recruit/main/header/style.module.scss
+++ b/src/widgets/recruit/main/header/style.module.scss
@@ -1,44 +1,44 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .recruit_header {
 	@include token.flex_column;
 	width: 100%;
-	gap: token.$spacing_2xl;
-	color: token.$text_normal;
-	padding: token.$spacing_3xl 0 token.$spacing_xl;
+	gap: token.$spacing_24;
+	color: token.$color_text_body;
+	padding: 28px 0 token.$spacing_20;
 	margin: 0 auto;
 
-	@include token.mobile {
-		gap: token.$spacing_lg;
-		padding: token.$spacing_xl 0 token.$spacing_md;
+	@include token.compact {
+		gap: token.$spacing_16;
+		padding: token.$spacing_20 0 token.$spacing_12;
 	}
 }
 
 .recruit_header_text {
 	@include token.flex_column;
-	gap: token.$spacing_sm;
+	gap: token.$spacing_8;
 
 	h2 {
-		@include token.heading_2;
+		@include token.heading_medium_bold;
 		/* heading_2 기본보다 큰 사이즈 적용 */
-		font-size: token.$font_size_2xl;
-		color: token.$text_strong;
+		font-size: token.$font_size_24;
+		color: token.$color_text_heading;
 	}
 
 	p {
-		@include token.body_medium;
+		@include token.body_medium_medium;
 		/* body_medium 기본보다 큰 사이즈 적용 */
-		font-size: token.$font_size_lg;
-		color: token.$text_subtle;
+		font-size: token.$font_size_18;
+		color: token.$color_text_caption;
 	}
 
-	@include token.mobile {
+	@include token.compact {
 		h2 {
-			font-size: token.$font_size_xl;
+			font-size: token.$font_size_20;
 		}
 
 		p {
-			font-size: token.$font_size_md;
+			font-size: token.$font_size_16;
 		}
 	}
 }
@@ -48,14 +48,14 @@
 	height: 1px;
 	border: none;
 	margin: 0;
-	background: token.$color_border_light;
+	background: token.$color_border_subtle;
 }
 
 .recruit_search {
 	display: flex;
 	align-items: center;
 	flex-wrap: wrap;
-	gap: token.$spacing_sm;
+	gap: token.$spacing_8;
 	width: 100%;
 }
 

--- a/src/widgets/recruit/main/list/style.module.scss
+++ b/src/widgets/recruit/main/list/style.module.scss
@@ -1,10 +1,10 @@
-@use "@bigtablet/design-system/scss/token" as token;
+@use "ds-token" as token;
 
 .request_list {
   @include token.flex_column;
   width: 100%;
   margin: 0 auto;
-  gap: token.$spacing_sm;
+  gap: token.$spacing_8;
 }
 
 /* empty/loading 자체에 min-height — list 전체는 자연 높이 유지해 viewport 초과 방지 */
@@ -15,60 +15,81 @@
   justify-content: center;
   min-height: 240px;
   text-align: center;
-  font-size: token.$font_size_md;
-  color: token.$text_subtle;
-  padding: token.$spacing_2xl 0;
+  font-size: token.$font_size_16;
+  color: token.$color_text_caption;
+  padding: token.$spacing_24 0;
 }
 
 .request_item {
   @include token.flex_between;
   align-items: flex-start;
   text-decoration: none;
-  color: token.$text_normal;
-  border: 1px solid token.$color_border;
+  color: token.$color_text_body;
+  border: 1px solid token.$color_border_default;
   border-radius: token.$radius_lg;
-  background: token.$color_background;
-  padding: token.$spacing_lg token.$spacing_xl;
+  background: token.$color_bg_solid;
+  padding: token.$spacing_16 token.$spacing_20;
   transition: transform token.$transition_base,
   border-color token.$transition_base,
   box-shadow token.$transition_base;
 
   &:hover {
     transform: translateY(-2px);
-    border-color: token.$color_primary_hover;
-    box-shadow: token.$shadow_sm;
+    border-color: token.$color_border_hover;
+    box-shadow: token.$elevation_level1;
   }
 }
 
 .request_item_left {
   @include token.flex_column;
-  gap: token.$spacing_md;
+  gap: token.$spacing_12;
 }
 
 .request_item_title {
-  @include token.heading_3;
-  font-size: token.$font_size_lg;
-  color: token.$text_strong;
+  @include token.heading_small_bold;
+  font-size: token.$font_size_18;
+  color: token.$color_text_heading;
 }
 
 .request_item_tags {
   display: flex;
   flex-wrap: wrap;
-  gap: token.$spacing_xs;
+  gap: token.$spacing_4;
 }
 
 .request_item_tag {
-  @include token.body_medium;
-  font-size: token.$font_size_xs;
-  color: token.$text_normal;
-  background: token.$color_background_secondary;
+  @include token.body_medium_medium;
+  font-size: token.$font_size_12;
+  color: token.$color_text_body;
+  background: token.$color_bg_solid_dim;
   border-radius: token.$radius_sm;
-  padding: token.$spacing_xs token.$spacing_sm;
+  padding: token.$spacing_4 token.$spacing_8;
 }
 
 .request_item_dday {
-  @include token.body_medium;
-  font-size: token.$font_size_sm;
-  color: token.$color_primary;
+  @include token.body_medium_medium;
+  font-size: token.$font_size_14;
+  color: token.$color_brand_primary;
   white-space: nowrap;
+}
+
+@include token.compact {
+  .request_item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: token.$spacing_8;
+    padding: token.$spacing_12 token.$spacing_16;
+  }
+
+  .request_item_title {
+    font-size: token.$font_size_16;
+  }
+
+  .request_item_tag {
+    font-size: token.$font_size_12;
+  }
+
+  .request_item_dday {
+    font-size: token.$font_size_12;
+  }
 }


### PR DESCRIPTION
## 제목
fix/responsive-i18n-sweep

## 작업한 내용
- [x] config: upgrade @bigtablet/design-system 1.22.0 -> 3.1.1 (local _ds-token.scss shim avoids per-module :root/[data-theme] css emission; ThemeProvider light mode; sassOptions.loadPaths bypasses exports subpath block)
- [x] refactor: migrate component api to 3.1 (Button filled/tonal/text+danger, TextField supportingText, Select -> Dropdown)
- [x] style: migrate scss tokens (spacing/font numeric, breakpoints compact/medium/expanded/large, typography mixins, var(--bt-*) colors) + responsive mobile blocks + restore brand gradient colors drifted by codemod
- [x] fix: footer crash on error/404 pages (async server -> client component) + member detail breadcrumb + route-loading bfcache bar

검증: build EXIT 0 (compile + typecheck + 13/13 static), lint clean (243 files), test 220/220, preview 확인 (home/404/gradient 렌더 정상)

## 전달할 추가 이슈
- 없음

Closes #399