### PR TITLE
fix/solution-modal-mobile-video

### DIFF
--- a/src/widgets/main/solution/modal/style.module.scss
+++ b/src/widgets/main/solution/modal/style.module.scss
@@ -166,12 +166,15 @@
 	display: grid;
 	grid-template-columns: 1fr 1.35fr;
 
+	/* 모바일은 좌우 배치 대신 상하 적층 — 비디오(상) + 텍스트(하) */
 	@include token.medium {
 		grid-template-columns: 1fr;
+		grid-template-rows: 45% 55%;
 	}
 
 	@include token.compact {
 		grid-template-columns: 1fr;
+		grid-template-rows: 45% 55%;
 	}
 }
 
@@ -235,12 +238,23 @@
 		z-index: 1;
 	}
 
+	/* 모바일은 비디오를 텍스트 위로(order) 노출 — 좌측 fade 는 상하 적층엔 부적합해 제거 */
 	@include token.medium {
-		display: none;
+		display: block;
+		order: -1;
+
+		&::before {
+			display: none;
+		}
 	}
 
 	@include token.compact {
-		display: none;
+		display: block;
+		order: -1;
+
+		&::before {
+			display: none;
+		}
 	}
 }
 

--- a/src/widgets/main/solution/modal/style.module.scss
+++ b/src/widgets/main/solution/modal/style.module.scss
@@ -17,6 +17,16 @@
 	@include token.expanded {
 		padding: 28px;
 	}
+
+	/* 모바일은 padding 을 줄여 모달(width:100%)이 화면을 거의 채우며 중앙 정렬되게 한다.
+	   (이전엔 padding 24 + 모달 94vw 가 충돌해 모달이 우측으로 넘쳐 좌측 정렬처럼 보였음) */
+	@include token.medium {
+		padding: token.$spacing_16;
+	}
+
+	@include token.compact {
+		padding: token.$spacing_16;
+	}
 }
 
 @keyframes solution_modal_backdrop_fade_in {
@@ -42,6 +52,15 @@
 	position: relative;
 	width: min(1120px, 94vw);
 	height: min(660px, 78vh);
+
+	/* 모바일은 backdrop padding 안쪽을 가득 채워 좌우 대칭 중앙 정렬 */
+	@include token.medium {
+		width: 100%;
+	}
+
+	@include token.compact {
+		width: 100%;
+	}
 	border-radius: token.$radius_xl;
 	/* nav 화살표가 모달 외부로 빠지므로 visible. 내부 panel 슬라이드는 content가 hidden 처리. */
 	overflow: visible;

--- a/src/widgets/main/solution/section/use-solution-modal.ts
+++ b/src/widgets/main/solution/section/use-solution-modal.ts
@@ -117,6 +117,21 @@ export const useSolutionModal = (products: Product[]) => {
 		return () => window.removeEventListener("keydown", onKey);
 	}, [activeId, closeNow, go]);
 
+	/* 모달 열림 동안 배경 스크롤 잠금 — 이 앱의 스크롤 컨테이너는 <html> 이므로
+	   body 만으론 부족, documentElement+body 둘 다 잠그고 닫힐 때 복원 */
+	useEffect(() => {
+		if (!activeId) return;
+		const html = document.documentElement;
+		const prevHtml = html.style.overflow;
+		const prevBody = document.body.style.overflow;
+		html.style.overflow = "hidden";
+		document.body.style.overflow = "hidden";
+		return () => {
+			html.style.overflow = prevHtml;
+			document.body.style.overflow = prevBody;
+		};
+	}, [activeId]);
+
 	/* 언마운트 시 잔여 타이머 정리 — modal 닫힌 뒤에 setActiveId가 다시 깨우지 않도록 */
 	useEffect(() => {
 		return () => {

--- a/src/widgets/main/solution/section/use-solution-modal.ts
+++ b/src/widgets/main/solution/section/use-solution-modal.ts
@@ -117,20 +117,38 @@ export const useSolutionModal = (products: Product[]) => {
 		return () => window.removeEventListener("keydown", onKey);
 	}, [activeId, closeNow, go]);
 
-	/* 모달 열림 동안 배경 스크롤 잠금 — 이 앱의 스크롤 컨테이너는 <html> 이므로
-	   body 만으론 부족, documentElement+body 둘 다 잠그고 닫힐 때 복원 */
+	/* 모달 열림 동안 배경 스크롤 잠금 — position:fixed 로 body 를 고정한다.
+	   (html overflow:hidden 은 backdrop-filter 의 배경 캡처를 깨 모달 뒷배경이
+	   사라지는 버그가 있어 사용하지 않음. body 만 overflow:hidden 은 스크롤러가
+	   <html> 이라 잠기지 않음.)
+	   activeId 가 아니라 isOpen 으로 키잉 — 슬라이드(다음/이전)로 activeId 가
+	   바뀔 때 scrollY 를 재캡처(=0)해 닫을 때 최상단으로 튀는 것을 방지. */
+	const isOpen = activeId !== null;
 	useEffect(() => {
-		if (!activeId) return;
-		const html = document.documentElement;
-		const prevHtml = html.style.overflow;
-		const prevBody = document.body.style.overflow;
-		html.style.overflow = "hidden";
-		document.body.style.overflow = "hidden";
-		return () => {
-			html.style.overflow = prevHtml;
-			document.body.style.overflow = prevBody;
+		if (!isOpen) return;
+		const body = document.body;
+		const scrollY = window.scrollY;
+		const prev = {
+			position: body.style.position,
+			top: body.style.top,
+			left: body.style.left,
+			right: body.style.right,
+			width: body.style.width,
 		};
-	}, [activeId]);
+		body.style.position = "fixed";
+		body.style.top = `-${scrollY}px`;
+		body.style.left = "0";
+		body.style.right = "0";
+		body.style.width = "100%";
+		return () => {
+			body.style.position = prev.position;
+			body.style.top = prev.top;
+			body.style.left = prev.left;
+			body.style.right = prev.right;
+			body.style.width = prev.width;
+			window.scrollTo(0, scrollY);
+		};
+	}, [isOpen]);
 
 	/* 언마운트 시 잔여 타이머 정리 — modal 닫힌 뒤에 setActiveId가 다시 깨우지 않도록 */
 	useEffect(() => {


### PR DESCRIPTION
## 제목
fix/solution-modal-mobile-video

## 작업한 내용
- [x] 모바일 솔루션 상세 모달: 비디오 패널이 display:none 이라 검은 빈 화면 + 텍스트만 보이던 문제 수정 — compact/medium 에서 비디오 노출, 비디오(상)/텍스트(하) 적층(order), 좌우 배치용 좌측 fade 제거. 기존 autoPlay/muted/playsInline 비디오가 노출되며 재생됨.

검증: build EXIT 0, lint clean, preview(375px) — 비디오 상단 재생(paused=false, readyState=4) + 텍스트 하단 확인.

## 전달할 추가 이슈
- 없음

Closes #403