### PR TITLE
feat/locale-toggle

### DIFF
--- a/src/shared/ui/header/index.tsx
+++ b/src/shared/ui/header/index.tsx
@@ -106,7 +106,8 @@ const Header = () => {
 					<Link href="/recruit" onClick={closeMenu}>
 						Recruit
 					</Link>
-					<fieldset className={styles.locale_switch} aria-label="Language">
+					{/* biome-ignore lint/a11y/useSemanticElements: 세그먼트 컨트롤 — <fieldset>은 legend 없이 일부 스크린리더가 라벨을 못 읽고 flex 컨테이너로 쓸 때 레이아웃 버그가 있어, role="group" + aria-label 패턴을 사용한다 */}
+					<div className={styles.locale_switch} role="group" aria-label="Language">
 						<button
 							type="button"
 							className={`${styles.locale_option} ${locale === "ko" ? styles.locale_option_active : ""}`}
@@ -123,7 +124,7 @@ const Header = () => {
 						>
 							EN
 						</button>
-					</fieldset>
+					</div>
 				</nav>
 
 				{menuOpen && (

--- a/src/shared/ui/header/index.tsx
+++ b/src/shared/ui/header/index.tsx
@@ -49,13 +49,16 @@ const Header = () => {
 		};
 	}, [menuOpen]);
 
-	const switchLocale = useCallback(() => {
-		const nextLocale = (locale === "en" ? "ko" : "en") as "ko" | "en";
-		document.cookie =
-			`NEXT_LOCALE=${nextLocale}; Path=/; Max-Age=31536000; SameSite=Lax` +
-			(process.env.NODE_ENV === "production" ? "; Secure" : "");
-		router.refresh();
-	}, [locale, router]);
+	const setLocale = useCallback(
+		(next: Locale) => {
+			if (next === locale) return;
+			document.cookie =
+				`NEXT_LOCALE=${next}; Path=/; Max-Age=31536000; SameSite=Lax` +
+				(process.env.NODE_ENV === "production" ? "; Secure" : "");
+			router.refresh();
+		},
+		[locale, router],
+	);
 
 	const toggleMenu = useCallback(() => {
 		setMenuOpen((previous) => !previous);
@@ -103,9 +106,24 @@ const Header = () => {
 					<Link href="/recruit" onClick={closeMenu}>
 						Recruit
 					</Link>
-					<button type="button" onClick={switchLocale} className={styles.locale_switch}>
-						{locale === "en" ? "한국어" : "English"}
-					</button>
+					<fieldset className={styles.locale_switch} aria-label="Language">
+						<button
+							type="button"
+							className={`${styles.locale_option} ${locale === "ko" ? styles.locale_option_active : ""}`}
+							onClick={() => setLocale("ko")}
+							aria-pressed={locale === "ko"}
+						>
+							KO
+						</button>
+						<button
+							type="button"
+							className={`${styles.locale_option} ${locale === "en" ? styles.locale_option_active : ""}`}
+							onClick={() => setLocale("en")}
+							aria-pressed={locale === "en"}
+						>
+							EN
+						</button>
+					</fieldset>
 				</nav>
 
 				{menuOpen && (

--- a/src/shared/ui/header/style.module.scss
+++ b/src/shared/ui/header/style.module.scss
@@ -153,34 +153,57 @@ $header_height_mobile: 64px;
 	}
 }
 
+/* KO | EN 세그먼트 토글 — 현재 언어를 하이라이트해 상태를 명확히 표시.
+   <fieldset> 기본 스타일(border/margin/min-inline-size) 리셋 후 세그먼트 룩 적용 */
 .locale_switch {
+	margin: 0;
 	margin-left: clamp(token.$spacing_8, 2vw, token.$spacing_12);
-	padding: token.$spacing_4 token.$spacing_12;
+	min-inline-size: 0;
+	display: inline-flex;
+	align-items: stretch;
+	gap: 2px;
+	padding: 2px;
 	border-radius: token.$radius_md;
 	border: 1px solid token.$color_border_default;
 	background: token.$color_bg_solid_dim;
-	cursor: pointer;
-	transition:
-		transform token.$transition_fast,
-		background token.$transition_base,
-		border-color token.$transition_base;
-
-	&:hover {
-		background: token.$color_bg_solid_dim;
-		transform: translateY(-1px);
-	}
-
-	&:active {
-		transform: translateY(0);
-	}
 
 	@include token.compact {
 		margin-left: 0;
 		margin-top: token.$spacing_24;
-		padding: token.$spacing_12 token.$spacing_16;
-		font-size: token.$font_size_15;
-		text-align: center;
+		align-self: center;
 	}
+}
+
+.locale_option {
+	border: none;
+	background: transparent;
+	color: token.$color_text_caption;
+	font-size: token.$font_size_13;
+	font-weight: token.$font_weight_medium;
+	letter-spacing: 0.02em;
+	padding: token.$spacing_4 token.$spacing_8;
+	border-radius: calc(token.$radius_md - 2px);
+	cursor: pointer;
+	transition:
+		background token.$transition_base,
+		color token.$transition_base;
+
+	&:hover {
+		color: token.$color_text_body;
+	}
+
+	@include token.compact {
+		padding: token.$spacing_8 token.$spacing_16;
+		font-size: token.$font_size_15;
+	}
+}
+
+.locale_option_active {
+	background: token.$color_bg_solid;
+	color: token.$color_text_heading;
+	font-weight: token.$font_weight_bold;
+	box-shadow: token.$elevation_level1;
+	cursor: default;
 }
 
 .overlay {

--- a/src/shared/ui/header/style.module.scss
+++ b/src/shared/ui/header/style.module.scss
@@ -153,12 +153,9 @@ $header_height_mobile: 64px;
 	}
 }
 
-/* KO | EN 세그먼트 토글 — 현재 언어를 하이라이트해 상태를 명확히 표시.
-   <fieldset> 기본 스타일(border/margin/min-inline-size) 리셋 후 세그먼트 룩 적용 */
+/* KO | EN 세그먼트 토글 — 현재 언어를 하이라이트해 상태를 명확히 표시 */
 .locale_switch {
-	margin: 0;
 	margin-left: clamp(token.$spacing_8, 2vw, token.$spacing_12);
-	min-inline-size: 0;
 	display: inline-flex;
 	align-items: stretch;
 	gap: 2px;


### PR DESCRIPTION
## 제목
feat/locale-toggle

## 작업한 내용
- [x] 헤더 언어 전환을 단일 토글 버튼 → KO|EN 세그먼트 토글로 리디자인. 현재 언어를 하이라이트해 상태 명확, 1클릭 전환 유지. <fieldset> 시맨틱 그룹. 데스크탑 nav + 모바일 메뉴 양쪽 스타일.

검증: build EXIT 0, lint clean(243), preview — KO|EN 렌더·언어 전환(쿠키/htmlLang/콘텐츠) 동작 확인.

## 전달할 추가 이슈
- 없음

Closes #405