### PR TITLE
feat/recruit-header-i18n

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -30,7 +30,7 @@
 		"header": {
 			"title": "Toward a World Beyond Pixels",
 			"description": "We're looking for partners to join Bigtablet on our journey.",
-			"searchPlaceholder": "Search by job or posting title.",
+			"searchPlaceholder": "Search by job or posting title",
 			"filterJob": "Job",
 			"filterEducation": "Education",
 			"filterCareer": "Employment Type",

--- a/messages/en.json
+++ b/messages/en.json
@@ -27,6 +27,15 @@
 		"notFoundDescription": "The page you requested does not exist\nor has been moved."
 	},
 	"recruit": {
+		"header": {
+			"title": "Toward a World Beyond Pixels",
+			"description": "We're looking for partners to join Bigtablet on our journey.",
+			"searchPlaceholder": "Search by job or posting title.",
+			"filterJob": "Job",
+			"filterEducation": "Education",
+			"filterCareer": "Employment Type",
+			"registerTalent": "Join Talent Pool"
+		},
 		"detail": {
 			"loading": "Loading…",
 			"loadFailed": "Failed to load.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -27,6 +27,15 @@
 		"notFoundDescription": "요청하신 페이지가 존재하지 않거나\n잘못된 접근입니다."
 	},
 	"recruit": {
+		"header": {
+			"title": "픽셀 너머의 세상을 향해",
+			"description": "빅태블릿의 여정을 함께하실 파트너 분들을 모집합니다.",
+			"searchPlaceholder": "직무 혹은 공고 이름으로 검색하실 수 있습니다.",
+			"filterJob": "직무",
+			"filterEducation": "학력",
+			"filterCareer": "고용형태",
+			"registerTalent": "인재풀 등록하기"
+		},
 		"detail": {
 			"loading": "불러오는 중…",
 			"loadFailed": "불러오지 못했습니다.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -30,7 +30,7 @@
 		"header": {
 			"title": "픽셀 너머의 세상을 향해",
 			"description": "빅태블릿의 여정을 함께하실 파트너 분들을 모집합니다.",
-			"searchPlaceholder": "직무 혹은 공고 이름으로 검색하실 수 있습니다.",
+			"searchPlaceholder": "직무 혹은 공고 이름으로 검색하실 수 있습니다",
 			"filterJob": "직무",
 			"filterEducation": "학력",
 			"filterCareer": "고용형태",

--- a/src/widgets/recruit/main/header/index.tsx
+++ b/src/widgets/recruit/main/header/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button, Dropdown, type DropdownOption, TextField } from "@bigtablet/design-system";
+import { useTranslations } from "next-intl";
 import { memo, useState } from "react";
 import type { RecruitSearchFilters } from "src/entities/recruit/api/recruit.api";
 import {
@@ -29,6 +30,7 @@ interface Props {
 }
 
 const RecruitHeader = ({ filters, onChange }: Props) => {
+	const t = useTranslations("recruit");
 	const patch = (partial: Partial<RecruitSearchFilters>) => onChange({ ...filters, ...partial });
 	const [open, setOpen] = useState(false);
 
@@ -36,13 +38,13 @@ const RecruitHeader = ({ filters, onChange }: Props) => {
 		<>
 			<header className={styles.recruit_header}>
 				<div className={styles.recruit_header_text}>
-					<h2>픽셀 너머의 세상을 향해</h2>
-					<p>빅태블릿의 여정을 함께하실 파트너 분들을 모집합니다.</p>
+					<h2>{t("header.title")}</h2>
+					<p>{t("header.description")}</p>
 				</div>
 
 				<div className={styles.recruit_search}>
 					<TextField
-						placeholder="직무 혹은 공고 이름으로 검색하실 수 있습니다."
+						placeholder={t("header.searchPlaceholder")}
 						value={filters.keyword ?? ""}
 						onChangeAction={(value) => patch({ keyword: value })}
 						size="sm"
@@ -50,7 +52,7 @@ const RecruitHeader = ({ filters, onChange }: Props) => {
 					/>
 
 					<Dropdown
-						placeholder="직무"
+						placeholder={t("header.filterJob")}
 						options={DEPARTMENT_OPTIONS}
 						value={filters.job ?? null}
 						onChange={(value) => patch({ job: value ?? "" })}
@@ -59,7 +61,7 @@ const RecruitHeader = ({ filters, onChange }: Props) => {
 					/>
 
 					<Dropdown
-						placeholder="학력"
+						placeholder={t("header.filterEducation")}
 						options={EDUCATION_OPTIONS}
 						value={filters.education ?? null}
 						onChange={(value) => patch({ education: value ?? "" })}
@@ -68,7 +70,7 @@ const RecruitHeader = ({ filters, onChange }: Props) => {
 					/>
 
 					<Dropdown
-						placeholder="고용형태"
+						placeholder={t("header.filterCareer")}
 						options={RECRUIT_TYPE_OPTIONS}
 						value={filters.career ?? null}
 						onChange={(value) => patch({ career: value ?? "" })}
@@ -82,7 +84,7 @@ const RecruitHeader = ({ filters, onChange }: Props) => {
 						className={styles.recruit_search_button}
 						onClick={() => setOpen(true)}
 					>
-						인재풀 등록하기
+						{t("header.registerTalent")}
 					</Button>
 				</div>
 


### PR DESCRIPTION
## 제목
feat/recruit-header-i18n

## 작업한 내용
- [x] recruit 헤더 하드코딩 한국어를 next-intl 키로 전환 (제목/부제/검색 placeholder/드롭다운 placeholder 3개/버튼)
- [x] messages ko.json, en.json 에 recruit.header 키 추가
- [x] ko/en 양 locale 렌더 검증 (콘솔 누락 키 경고 없음)

## 전달할 추가 이슈
- 드롭다운 옵션 라벨(departmentLabel/educationLabel/recruitTypeLabel/locationLabel)은 util/adapter·util/date 등 순수 데이터 변환 util 에서 카드 태그 생성에 쓰여 hook 사용 불가. 도메인 enum 라벨 i18n 은 별도 작업 필요.

Closes #415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * 모집 섹션의 헤더 UI 텍스트를 영어·한국어로 추가(제목, 설명, 검색 플레이스홀더, 직무/학력/경력 필터 라벨, 인재 등록 CTA).
  * 헤더 화면이 하드코딩 대신 지역화된 문자열을 사용하도록 전환되어 검색 및 필터 플레이스홀더가 현지화됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->