### PR TITLE
config/bump-design-system-3.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"prepare": "husky"
 	},
 	"dependencies": {
-		"@bigtablet/design-system": "3.1.1",
+		"@bigtablet/design-system": "3.2.2",
 		"@gsap/react": "^2.1.2",
 		"@hookform/resolvers": "^5.4.0",
 		"@next/bundle-analyzer": "^16.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     dependencies:
       '@bigtablet/design-system':
-        specifier: 3.1.1
-        version: 3.1.1(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.2.2
+        version: 3.2.2(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@gsap/react':
         specifier: ^2.1.2
         version: 2.1.2(gsap@3.15.0)(react@19.2.6)
@@ -277,8 +277,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bigtablet/design-system@3.1.1':
-    resolution: {integrity: sha512-kKmr3RbHlZMPJ4In7SBmczAKmWf0Mhgjpx/hhavWXyvRJoRGw/8V7sS4rITrigg71gvt+jUlUZRa53aQowA8TQ==}
+  '@bigtablet/design-system@3.2.2':
+    resolution: {integrity: sha512-8CXGUn4RguCmYTe09FoA/m5+uqg5mFJqJb/0rR5gPty4KWBtsgY9cxZspYQovKR9pMm1X7ngqNRXl1lvo2RF7w==}
     peerDependencies:
       lucide-react: '>=0.552.0'
       next: '>=16'
@@ -4283,7 +4283,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bigtablet/design-system@3.1.1(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@bigtablet/design-system@3.2.2(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@react-spring/web': 10.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       lucide-react: 1.17.0(react@19.2.6)


### PR DESCRIPTION
## 제목
config/bump-design-system-3.2.2

## 작업한 내용
- [x] @bigtablet/design-system 3.1.1 → 3.2.2 (exact pin 유지, package.json + lockfile)
- [x] tsc / lint / vitest(216) 통과 — DS API 호환성 깨짐 없음
- [x] preview 렌더 확인, 콘솔 에러 0, 3.2.2 status 토큰 적용 확인

## 전달할 추가 이슈
- status 색이 AA 대비로 어두워짐 (error #ef4444→#b91c1c, success #10b981→#047857). 라이트 전용이라 dark mode neutral 변경 영향은 없음
- 신규 컴포넌트 채택(ErrorState/Skeleton/RadioGroup/Textarea) + navy 하드코딩 11건 → accent 토큰 치환은 별도 작업

Closes #431