### PR TITLE
fix/form-validation-client-quality

### DIFF
--- a/src/features/recruit/apply/form/model/apply.schema.ts
+++ b/src/features/recruit/apply/form/model/apply.schema.ts
@@ -56,9 +56,6 @@ const baseSchema = z.object({
 export const applySchema = baseSchema.superRefine((data, ctx) => {
 	const isGed = data.educationLevel === "GED";
 
-	const admission = Number(data.admissionYear);
-	const graduation = Number(data.graduationEnd);
-
 	if (isGed) {
 		if (!data.admissionYear) {
 			ctx.addIssue({
@@ -87,7 +84,8 @@ export const applySchema = baseSchema.superRefine((data, ctx) => {
 		}
 	}
 
-	if (!Number.isNaN(admission) && !Number.isNaN(graduation) && graduation < admission) {
+	/* "YYYY-MM"은 zero-pad 포맷이라 사전순 비교가 시간순과 일치 */
+	if (data.admissionYear && data.graduationEnd && data.graduationEnd < data.admissionYear) {
 		ctx.addIssue({
 			code: "custom",
 			path: ["graduationEnd"],

--- a/src/features/recruit/test/apply.schema.test.ts
+++ b/src/features/recruit/test/apply.schema.test.ts
@@ -102,4 +102,20 @@ describe("applySchema", () => {
 		});
 		expect(result.success).toBe(false);
 	});
+
+	/* MonthPickerField 실제 출력 포맷("YYYY-MM") 기준 교차검증. 과거 Number() 파싱은 NaN으로 죽어 있었음 */
+	it('"YYYY-MM" 졸업이 입학보다 이전이면 실패', () => {
+		const result = applySchema.safeParse({
+			...base,
+			admissionYear: "2024-03",
+			graduationEnd: "2022-05",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('"YYYY-MM" 졸업이 입학 이후면 통과', () => {
+		expect(() =>
+			applySchema.parse({ ...base, admissionYear: "2020-03", graduationEnd: "2024-02" }),
+		).not.toThrow();
+	});
 });

--- a/src/features/talent/form/model/use-talent-form.ts
+++ b/src/features/talent/form/model/use-talent-form.ts
@@ -1,9 +1,14 @@
 "use client";
 
 import { useToast } from "@bigtablet/design-system";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useState } from "react";
-import { useFieldArray, useForm } from "react-hook-form";
-import type { PostTalent, PostTalentFormValues } from "src/entities/talent/schema/talent.schema";
+import { type Resolver, useFieldArray, useForm } from "react-hook-form";
+import {
+	type PostTalent,
+	type PostTalentFormValues,
+	postTalentSchema,
+} from "src/entities/talent/schema/talent.schema";
 import { useTalentMutation } from "src/features/talent/mutation/talent.mutation";
 import { useUploadMutation } from "src/features/upload/mutation/upload.mutation";
 import { getErrorMessage } from "src/shared/libs/api/axios/error/error.util";
@@ -29,6 +34,7 @@ export const useTalentForm = ({ onClose }: UseTalentFormParams) => {
 	const [portfolioMode, setPortfolioMode] = useState<PortfolioMode>("link");
 
 	const form = useForm<PostTalentFormValues>({
+		resolver: zodResolver(postTalentSchema) as Resolver<PostTalentFormValues>,
 		defaultValues: {
 			email: "",
 			name: "",

--- a/src/features/talent/test/use-talent-form.test.ts
+++ b/src/features/talent/test/use-talent-form.test.ts
@@ -154,7 +154,7 @@ describe("useTalentForm", () => {
 			);
 		});
 
-		it("빈 문자열 portfolioUrl은 그대로 빈 문자열로 유지한다", async () => {
+		it("빈 portfolioUrl은 검증(zodResolver)에 막혀 제출되지 않는다", async () => {
 			mockCreateTalent.mockResolvedValue(undefined);
 			const { result } = renderHook(() => useTalentForm({ onClose }));
 			fillBaseForm(result, { portfolioUrl: "" });
@@ -163,7 +163,8 @@ describe("useTalentForm", () => {
 				await result.current.handleSubmit();
 			});
 
-			expect(mockCreateTalent).toHaveBeenCalledWith(expect.objectContaining({ portfolioUrl: "" }));
+			expect(mockCreateTalent).not.toHaveBeenCalled();
+			expect(result.current.form.getFieldState("portfolioUrl").error).toBeDefined();
 		});
 
 		it("이미 https://가 있는 URL은 그대로 유지한다", async () => {

--- a/src/widgets/about/history/index.tsx
+++ b/src/widgets/about/history/index.tsx
@@ -80,8 +80,9 @@ const History = ({ items }: Props) => {
 
 	useEffect(() => {
 		if (!activeGroup) return;
-		const id = requestAnimationFrame(animateIn);
-		return () => cancelAnimationFrame(id);
+		/* gsap.context로 스코프. 언마운트/연도 전환 시 revert로 생성된 트윈을 전부 정리 */
+		const ctx = gsap.context(animateIn, contentRef);
+		return () => ctx.revert();
 	}, [activeGroup, animateIn]);
 
 	return (

--- a/src/widgets/about/history/index.tsx
+++ b/src/widgets/about/history/index.tsx
@@ -79,9 +79,9 @@ const History = ({ items }: Props) => {
 	);
 
 	useEffect(() => {
-		if (activeGroup) {
-			requestAnimationFrame(animateIn);
-		}
+		if (!activeGroup) return;
+		const id = requestAnimationFrame(animateIn);
+		return () => cancelAnimationFrame(id);
 	}, [activeGroup, animateIn]);
 
 	return (

--- a/src/widgets/layout/provider/index.tsx
+++ b/src/widgets/layout/provider/index.tsx
@@ -3,7 +3,7 @@
 import { AlertProvider, ThemeProvider, ToastProvider } from "@bigtablet/design-system";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import dynamic from "next/dynamic";
-import { type ReactNode, useMemo } from "react";
+import { type ReactNode, useState } from "react";
 import { isHttpError } from "src/shared/libs/api/error";
 import { createMutationCache } from "src/shared/libs/api/query/mutation-cache";
 import ToastBridgeProvider from "src/shared/libs/api/toast/toast-bridge-provider";
@@ -16,7 +16,8 @@ const DeferredCookieConsent = dynamic(() => import("src/features/cookie-consent/
 type Props = { children: ReactNode };
 
 export default function Providers({ children }: Props) {
-	const queryClient = useMemo(
+	/* useState 지연 초기화. useMemo는 React가 폐기 가능해 캐시 유실 위험 */
+	const [queryClient] = useState(
 		() =>
 			new QueryClient({
 				mutationCache: createMutationCache(),
@@ -34,7 +35,6 @@ export default function Providers({ children }: Props) {
 					},
 				},
 			}),
-		[],
 	);
 
 	return (


### PR DESCRIPTION
## 제목
fix/form-validation-client-quality

## 작업한 내용
- [x] apply.schema: 졸업일>입학일 교차검증이 Number() 파싱(NaN)으로 죽어 있던 것을 "YYYY-MM" 문자열 비교로 수정 + 실제 포맷 회귀 테스트 추가
- [x] talent 폼: useForm에 zodResolver(postTalentSchema) 연결 (이메일 형식/필수값 클라 검증). 빈 portfolioUrl 제출 가정 테스트를 검증 차단 동작으로 갱신
- [x] providers: QueryClient를 useMemo → useState 지연 초기화 (캐시 유실 방지)
- [x] about/history: requestAnimationFrame cleanup(cancelAnimationFrame) 추가

## 전달할 추가 이슈
- 없음

Closes #446