### PR TITLE
bug/csp-nonce-wiring

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -42,18 +42,21 @@ export function proxy(request: NextRequest) {
 		return NextResponse.redirect(to, 308);
 	}
 
-	// CSP nonce 생성
+	// CSP nonce 생성 및 정책 빌드 (요청·응답 양쪽에 동일 정책 적용)
 	const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+	const csp = buildCsp(nonce);
 
 	const requestHeaders = new Headers(request.headers);
 	requestHeaders.set("x-nonce", nonce);
+	/* 요청헤더에 CSP가 있어야 Next가 nonce를 프레임워크 스크립트에 자동 부착한다 (strict-dynamic 동작 조건) */
+	requestHeaders.set("Content-Security-Policy", csp);
 
 	const response = NextResponse.next({ request: { headers: requestHeaders } });
 	/**
 	 * 운영에서는 CSP 강제(enforce). report-only는 검사기에서 high로 평가됨.
 	 * 깨지는 inline script/style이 발견되면 nonce 부여 또는 정책 완화로 대응.
 	 */
-	response.headers.set("Content-Security-Policy", buildCsp(nonce));
+	response.headers.set("Content-Security-Policy", csp);
 
 	// locale 쿠키 자동 설정
 	if (!request.cookies.has(LOCALE_COOKIE_KEY)) {

--- a/src/test/proxy.test.ts
+++ b/src/test/proxy.test.ts
@@ -99,6 +99,19 @@ describe("proxy", () => {
 			expect(mockNext).toHaveBeenCalled();
 			expect(mockRedirect).not.toHaveBeenCalled();
 		});
+
+		it("요청헤더에 CSP를 설정해 Next가 스크립트에 nonce를 부착하게 한다", () => {
+			proxy(makeRequest("/about"));
+
+			const opts = mockNext.mock.calls[0]?.[0] as { request: { headers: Headers } } | undefined;
+			const requestCsp = opts?.request.headers.get("Content-Security-Policy");
+			const nonce = opts?.request.headers.get("x-nonce");
+
+			expect(nonce).toBeTruthy();
+			expect(requestCsp).toContain(`'nonce-${nonce}'`);
+			// 응답헤더 CSP와 동일 nonce 사용
+			expect(mockNextHeaders.get("Content-Security-Policy")).toBe(requestCsp);
+		});
 	});
 
 	describe("locale cookie", () => {


### PR DESCRIPTION
## 제목
bug/csp-nonce-wiring

## 작업한 내용
- [x] proxy.ts에서 CSP를 1회 빌드해 요청헤더에도 설정 (Next 공식 패턴) → Next가 프레임워크 스크립트에 nonce 자동 부착
- [x] proxy.test.ts에 요청헤더 CSP/nonce 단언 추가
- [x] 프로덕션 빌드 검증: 스크립트 37개 전부 nonce 부착, 응답 CSP 헤더 nonce와 일치 확인

## 배경
nonce를 생성해 응답 CSP에는 넣었으나 요청헤더에는 설정하지 않아, Next가 스크립트에 nonce를 못 붙였습니다. 응답 CSP는 'strict-dynamic'을 강제하므로 nonce 없는 스크립트는 운영에서 전부 차단됩니다. 요청헤더에도 동일 CSP를 설정해 해결했습니다.

## 전달할 추가 이슈
- 업로드 파일 검증(validate.ts)은 클라 측 file.type 검사라 위조 가능 → 서버측 타입/크기 검증 여부 확인 필요 (백엔드 범위)

Closes #448