### PR TITLE
config/dependabot-react-group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,14 @@ updates:
       - dependencies
     commit-message:
       prefix: "config"
+    groups:
+      # react 계열은 버전이 같이 가야 하므로 한 PR로 묶음 (react-dom 누락 방지)
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
     ignore:
       # major 버전 업은 수동으로 검토
       - dependency-name: "*"


### PR DESCRIPTION
## 제목
config/dependabot-react-group

## 작업한 내용
- [x] .github/dependabot.yml npm 블록에 react 그룹 추가 (react / react-dom / @types/react / @types/react-dom 동시 범프)

## 배경
dependabot이 react·@types/react만 올리고 react-dom을 19.2.6으로 남겨 "react와 react-dom 버전 불일치"로 CI가 깨졌습니다(#441). react 계열을 한 그룹으로 묶어 항상 같이 범프되게 합니다.

## 전달할 추가 이슈
- 없음

Closes #452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 의존성 업데이트 구성을 개선하여 관련 패키지 업데이트가 하나의 PR로 통합되도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->