### PR TITLE
fix/pnpm-overrides-migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,17 +73,5 @@
 		"**/*.{ts,tsx,js,jsx,json}": [
 			"biome check --write --no-errors-on-unmatched"
 		]
-	},
-	"pnpm": {
-		"overrides": {
-			"postcss@<8.5.10": "^8.5.10",
-			"fast-uri@<3.1.2": "^3.1.2",
-			"undici@<7.28.0": "^7.28.0",
-			"form-data@<4.0.6": "^4.0.6",
-			"ws@<7.5.11": "^7.5.11",
-			"js-yaml@<4.2.0": "^4.2.0",
-			"@babel/core@<7.29.6": "^7.29.6",
-			"@opentelemetry/core@<2.8.0": "^2.8.0"
-		}
 	}
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+# pnpm 10+는 overrides 등 설정을 package.json "pnpm" 필드가 아니라 이 파일에서 읽는다.
+# 아래는 취약 transitive 의존성 보안 핀 (구 package.json pnpm.overrides에서 이전).
+overrides:
+  'postcss@<8.5.10': '^8.5.10'
+  'fast-uri@<3.1.2': '^3.1.2'
+  'undici@<7.28.0': '^7.28.0'
+  'form-data@<4.0.6': '^4.0.6'
+  'ws@<7.5.11': '^7.5.11'
+  'js-yaml@<4.2.0': '^4.2.0'
+  '@babel/core@<7.29.6': '^7.29.6'
+  '@opentelemetry/core@<2.8.0': '^2.8.0'


### PR DESCRIPTION
## 제목
fix/pnpm-overrides-migration

## 작업한 내용
- [x] pnpm 10.32가 안 읽는 package.json `pnpm.overrides`를 `pnpm-workspace.yaml` overrides로 이전 (보안 핀 8건 무력화 방지)
- [x] 검증: 경고 제거, lockfile 불변(핀 유지: undici 7.28.0 / ws 7.5.11 / js-yaml 4.2.0 / form-data 4.0.6 / postcss 8.5.x / fast-uri 3.1.2), pnpm audit 취약점 0, tsc/lint/test(219)/build 통과

## 전달할 추가 이슈
- 없음

Closes #466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 의존성 버전 고정 설정을 새 위치로 정리해, 일부 취약한 간접 의존성의 버전 관리가 더 일관되게 적용되도록 했습니다.
  * 기존에 유지되던 패키지별 버전 제한 설정은 제거되고, 최신 pnpm 방식에 맞춰 관리되도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->